### PR TITLE
Fix LWWW -> LWW typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Tables are modeled as [GSets](<https://en.wikipedia.org/wiki/Conflict-free_repli
 
 ## Rows
 
-Rows are currently modeled as [LWWW maps](https://bartoszsypytkowski.com/crdt-map/#crdtmapwithlastwritewinsupdates). I.e., each column in a row is a [LWW Register](https://bartoszsypytkowski.com/operation-based-crdts-registers-and-sets/#lastwritewinsregister).
+Rows are currently modeled as [LWW maps](https://bartoszsypytkowski.com/crdt-map/#crdtmapwithlastwritewinsupdates). I.e., each column in a row is a [LWW Register](https://bartoszsypytkowski.com/operation-based-crdts-registers-and-sets/#lastwritewinsregister).
 
 Things to support in the future
 


### PR DESCRIPTION
Hi there!

I just noted what I think is a minor typo in the README. `LWWW` should probably be `LWW` (unless it's a different conflict strategy).

Awesome work on this project btw; I'm really excited to watch it progress :)