### PR TITLE
Fix multi way merge bug 🤦‍♂️

### DIFF
--- a/js/examples/p2p-todomvc/src/main.tsx
+++ b/js/examples/p2p-todomvc/src/main.tsx
@@ -12,7 +12,7 @@ import wdbRtc from "@vlcn.io/network-webrtc";
 async function main() {
   const sqlite = await sqliteWasm();
 
-  const db = await sqlite.open("p2p-wdb-todomvc3");
+  const db = await sqlite.open("p2p-wdb-todomvc-5");
   (window as any).db = db;
 
   await db.exec(

--- a/js/examples/p2p-todomvc/src/main.tsx
+++ b/js/examples/p2p-todomvc/src/main.tsx
@@ -12,7 +12,7 @@ import wdbRtc from "@vlcn.io/network-webrtc";
 async function main() {
   const sqlite = await sqliteWasm();
 
-  const db = await sqlite.open("p2p-wdb-todomvc2");
+  const db = await sqlite.open("p2p-wdb-todomvc3");
   (window as any).db = db;
 
   await db.exec(

--- a/js/replicators/whole-db/src/WholeDbReplicator.ts
+++ b/js/replicators/whole-db/src/WholeDbReplicator.ts
@@ -289,7 +289,7 @@ export class WholeDbReplicator {
       return;
     }
     log("pushing changesets across the network", changes);
-    console.log(changes);
+    // console.log(changes);
     this.network.pushChanges(from, changes);
   };
 }

--- a/js/replicators/whole-db/src/WholeDbReplicator.ts
+++ b/js/replicators/whole-db/src/WholeDbReplicator.ts
@@ -289,6 +289,7 @@ export class WholeDbReplicator {
       return;
     }
     log("pushing changesets across the network", changes);
+    console.log(changes);
     this.network.pushChanges(from, changes);
   };
 }

--- a/native/src/changes-vtab-write.c
+++ b/native/src/changes-vtab-write.c
@@ -135,14 +135,13 @@ int crsql_setWinnerClock(
       VALUES (\
         %s,\
         %Q,\
-        %lld,\
+        crsql_nextdbversion(),\
         ?\
       )",
       tblInfo->tblName,
       pkIdentifierList,
       pkValsStr,
-      insertColName,
-      insertVrsn);
+      insertColName);
 
   sqlite3_stmt *pStmt = 0;
   rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
@@ -206,6 +205,7 @@ int crsql_mergePkOnlyInsert(
     return rc;
   }
 
+  // TODO: if insert was ignored, no reason to change clock
   return crsql_setWinnerClock(
       db,
       tblInfo,

--- a/native/src/changes-vtab-write.c
+++ b/native/src/changes-vtab-write.c
@@ -135,13 +135,14 @@ int crsql_setWinnerClock(
       VALUES (\
         %s,\
         %Q,\
-        crsql_nextdbversion(),\
+        MAX(crsql_nextdbversion(), %lld),\
         ?\
       )",
       tblInfo->tblName,
       pkIdentifierList,
       pkValsStr,
-      insertColName);
+      insertColName,
+      insertVrsn);
 
   sqlite3_stmt *pStmt = 0;
   rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);

--- a/native/src/changes-vtab.c
+++ b/native/src/changes-vtab.c
@@ -199,6 +199,7 @@ static int changesNext(sqlite3_vtab_cursor *cur)
   const char *pks = (const char *)sqlite3_column_text(pCur->pChangesStmt, PKS);
   const char *cid = (const char *)sqlite3_column_text(pCur->pChangesStmt, CID);
   sqlite3_int64 vrsn = sqlite3_column_int64(pCur->pChangesStmt, VRSN);
+  pCur->version = vrsn;
 
   crsql_TableInfo *tblInfo = crsql_findTableInfo(
       pCur->pTab->pExtData->zpTableInfos,
@@ -265,7 +266,6 @@ static int changesNext(sqlite3_vtab_cursor *cur)
   }
 
   pCur->pRowStmt = pRowStmt;
-  pCur->version = vrsn;
 
   return rc;
 }

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,6 @@
 todo:
 
+- update the p2p example to forward messages on behalf of other peers?
 - site id must be proxied thru given comparison against it as a tie breaker
 - delete doesn't record version? tech. ok given delete wins but it is information loss.
 - relay / daisy chain data from peers via poke after receive.

--- a/py/correctness/tests/test_sync.py
+++ b/py/correctness/tests/test_sync.py
@@ -98,7 +98,7 @@ def test_delete():
   rows = get_changes_since(db, 1, -1)
   siteid = db.execute("select crsql_siteid()").fetchone()[0]
   # Deletes are marked with a sentinel id
-  assert(rows == [('component', '1', '__crsql_del', None, 0, siteid)]);
+  assert(rows == [('component', '1', '__crsql_del', None, 2, siteid)]);
 
   db.execute("DELETE FROM component")
   db.execute("DELETE FROM deck")
@@ -110,32 +110,31 @@ def test_delete():
   # given we have past events that we're missing data for, they're now marked off as deletes
   # TODO: should deletes not get a proper version? Would be better for ordering and chunking replications
   assert(rows == [
-    ("component", "1", "__crsql_del", None, 0, siteid),
-    ("component", "1", "__crsql_del", None, 0, siteid),
-    ("component", "1", "__crsql_del", None, 0, siteid),
-    ("component", "2", "__crsql_del", None, 0, siteid),
-    ("component", "2", "__crsql_del", None, 0, siteid),
-    ("component", "2", "__crsql_del", None, 0, siteid),
-    ("component", "3", "__crsql_del", None, 0, siteid),
-    ("component", "3", "__crsql_del", None, 0, siteid),
-    ("component", "3", "__crsql_del", None, 0, siteid),
-    ("deck", "1", "__crsql_del", None, 0, siteid),
-    ("deck", "1", "__crsql_del", None, 0, siteid),
-    ("slide", "1", "__crsql_del", None, 0, siteid),
-    ("slide", "1", "__crsql_del", None, 0, siteid),
-    ("slide", "2", "__crsql_del", None, 0, siteid),
-    ("slide", "2", "__crsql_del", None, 0, siteid),
-    ("slide", "3", "__crsql_del", None, 0, siteid),
-    ("slide", "3", "__crsql_del", None, 0, siteid),
-    ("user", "1", "name", "'Javi'", 1, siteid),
+    ("component", "1", "__crsql_del", None, 1, siteid),
+    ("component", "1", "__crsql_del", None, 1, siteid),
     ("component", "1", "__crsql_del", None, 1, siteid),
     ("component", "2", "__crsql_del", None, 1, siteid),
+    ("component", "2", "__crsql_del", None, 1, siteid),
+    ("component", "2", "__crsql_del", None, 1, siteid),
+    ("component", "3", "__crsql_del", None, 1, siteid),
+    ("component", "3", "__crsql_del", None, 1, siteid),
     ("component", "3", "__crsql_del", None, 1, siteid),
     ("deck", "1", "__crsql_del", None, 1, siteid),
+    ("deck", "1", "__crsql_del", None, 1, siteid),
+    ("slide", "1", "__crsql_del", None, 1, siteid),
     ("slide", "1", "__crsql_del", None, 1, siteid),
     ("slide", "2", "__crsql_del", None, 1, siteid),
+    ("slide", "2", "__crsql_del", None, 1, siteid),
     ("slide", "3", "__crsql_del", None, 1, siteid),
-]);
+    ("slide", "3", "__crsql_del", None, 1, siteid),
+    ("user", "1", "name", "'Javi'", 1, siteid),
+    ("component", "1", "__crsql_del", None, 2, siteid),
+    ("component", "2", "__crsql_del", None, 3, siteid),
+    ("component", "3", "__crsql_del", None, 3, siteid),
+    ("deck", "1", "__crsql_del", None, 3, siteid),
+    ("slide", "1", "__crsql_del", None, 3, siteid),
+    ("slide", "2", "__crsql_del", None, 3, siteid),
+    ("slide", "3", "__crsql_del", None, 3, siteid)]);
 
   # test insert
 


### PR DESCRIPTION
1. We weren't moving our logical clock forward on merge of a winner
2. We didn't return the logical clock value of deletes

3+ way merge works fine now --

https://user-images.githubusercontent.com/1009003/204034968-54d8b9c5-b3b3-4c48-b2ac-27e0b83843e1.mov

Need to resurrect unit and integration tests for multi way merges --
https://github.com/vlcn-io/cr-sqlite/blob/orig-approach/prototype/replicator/src/__tests__/merge-random-1.test.ts
https://github.com/vlcn-io/cr-sqlite/blob/orig-approach/prototype/replicator/src/__tests__/merge-random-2.test.ts

that we never ported over when we re-wrote the implementation from TypeScript to C.