### PR TITLE
Fix Windows build by rewriting c99 specific code

### DIFF
--- a/native/src/changes-vtab-read.c
+++ b/native/src/changes-vtab-read.c
@@ -62,7 +62,7 @@ char *crsql_changesUnionQuery(
     crsql_TableInfo **tableInfos,
     int tableInfosLen)
 {
-  char *unionsArr[tableInfosLen];
+  char **unionsArr = sqlite3_malloc(tableInfosLen * sizeof(char *));
   char *unionsStr = 0;
   int i = 0;
 
@@ -92,6 +92,7 @@ char *crsql_changesUnionQuery(
   {
     sqlite3_free(unionsArr[i]);
   }
+  sqlite3_free(unionsArr);
 
   // compose the final query
   return sqlite3_mprintf(

--- a/native/src/tableinfo.c
+++ b/native/src/tableinfo.c
@@ -73,13 +73,15 @@ static char *quote(const char *in)
 
 char *crsql_quoteConcat(crsql_ColumnInfo *cols, int len)
 {
-  char *names[len];
+  char **names = sqlite3_malloc(len * sizeof(char *));
   for (int i = 0; i < len; ++i)
   {
     names[i] = cols[i].name;
   }
 
-  return crsql_join2(&quote, names, len, " || '|' || ");
+  char *ret = crsql_join2(&quote, names, len, " || '|' || ");
+  sqlite3_free(names);
+  return ret;
 }
 
 static void crsql_freeColumnInfos(crsql_ColumnInfo *columnInfos, int len)

--- a/native/src/triggers.c
+++ b/native/src/triggers.c
@@ -75,7 +75,8 @@ int crsql_createInsertTrigger(
 
 char *crsql_insertTriggerQuery(crsql_TableInfo *tableInfo, char *pkList, char *pkNewList)
 {
-  char *subTriggers[tableInfo->nonPksLen == 0 ? 1 : tableInfo->nonPksLen];
+  const int length = tableInfo->nonPksLen == 0 ? 1 : tableInfo->nonPksLen;
+  char **subTriggers = sqlite3_malloc(length * sizeof(char *));
   char *joinedSubTriggers;
 
   // We need a CREATE_SENTINEL to stand in for the create event so we can replicate PKs
@@ -132,6 +133,7 @@ char *crsql_insertTriggerQuery(crsql_TableInfo *tableInfo, char *pkList, char *p
   {
     sqlite3_free(subTriggers[0]);
   }
+  sqlite3_free(subTriggers);
 
   return joinedSubTriggers;
 }
@@ -153,7 +155,7 @@ int crsql_createUpdateTrigger(sqlite3 *db,
   char *pkList = 0;
   char *pkNewList = 0;
   int rc = SQLITE_OK;
-  char *subTriggers[tableInfo->nonPksLen];
+  char **subTriggers = sqlite3_malloc(tableInfo->nonPksLen * sizeof(char*));
   char *joinedSubTriggers;
 
   if (tableInfo->nonPksLen == 0)
@@ -195,6 +197,7 @@ int crsql_createUpdateTrigger(sqlite3 *db,
   {
     sqlite3_free(subTriggers[i]);
   }
+  sqlite3_free(subTriggers);
 
   zSql = sqlite3_mprintf("CREATE TRIGGER IF NOT EXISTS \"%s__crsql_utrig\"\
       AFTER UPDATE ON \"%s\"\

--- a/native/src/util.c
+++ b/native/src/util.c
@@ -48,7 +48,7 @@ static char *joinHelper(char **in, size_t inlen, size_t inpos, size_t accum)
 {
   if (inpos == inlen)
   {
-    return strcpy(sqlite3_malloc(accum + 1) + accum, "");
+    return strcpy((char *)sqlite3_malloc(accum + 1) + accum, "");
   }
   else
   {
@@ -103,7 +103,7 @@ char *crsql_join2(char *(*map)(const char *), char **in, size_t len, char *delim
     return 0;
   }
 
-  char *toJoin[len];
+  char **toJoin = sqlite3_malloc(len * sizeof(char *));
   int resultLen = 0;
   char *ret = 0;
   for (size_t i = 0; i < len; ++i)
@@ -132,6 +132,7 @@ char *crsql_join2(char *(*map)(const char *), char **in, size_t len, char *delim
 
     sqlite3_free(toJoin[i]);
   }
+  sqlite3_free(toJoin);
 
   return ret;
 }
@@ -299,7 +300,7 @@ char *crsql_asIdentifierListStr(char **in, size_t inlen, char delim)
 {
   int finalLen = 0;
   char *ret = 0;
-  char *mapped[inlen];
+  char **mapped = sqlite3_malloc(inlen * sizeof(char *));
 
   for (size_t i = 0; i < inlen; ++i)
   {
@@ -321,6 +322,7 @@ char *crsql_asIdentifierListStr(char **in, size_t inlen, char delim)
   {
     sqlite3_free(mapped[i]);
   }
+  sqlite3_free(mapped);
 
   return ret;
 }
@@ -337,7 +339,7 @@ char *crsql_getDbVersionUnionQuery(
     int numRows,
     char **tableNames)
 {
-  char *unionsArr[numRows];
+  char **unionsArr = sqlite3_malloc(numRows * sizeof(char *));
   char *unionsStr;
   char *ret;
   int i = 0;
@@ -360,6 +362,7 @@ char *crsql_getDbVersionUnionQuery(
   {
     sqlite3_free(unionsArr[i]);
   }
+  sqlite3_free(unionsArr);
 
   // compose the final query
   // and update the pointer to the string to point to it.


### PR DESCRIPTION
I didn't manage to get `make` running on my Windows setup. So, compiled everything manually with `cl` using the following commands:

**loadable**:
```bash
cl /I src/ /I src/sqlite /O2 /LD /DSQLITE_PATH_DATE="\"2022-12-04T18:57:31Z+0700\"" /DSQLITE_PATH_VERSION="\"v0.1.0\"" /DSQLITE_PATH_SOURCE="\"eaffe9f47859b6bf6926912d5006d64a1be94896\"" src/crsqlite.c src/util.c src/tableinfo.c src/triggers.c src/changes-vtab.c src/changes-vtab-read.c src/changes-vtab-common.c src/changes-vtab-write.c src/ext-data.c src/get-table.c /link /OUT:dist/crsqlite.dll
```

**sqlite3**:
```bash
cl /DSQLITE_PATH_DATE="\"2022-12-04T19:56:46Z+0700\"" /DSQLITE_PATH_VERSION="\"v0.1.0\"" /DSQLITE_PATH_SOURCE="\"208b529213d5c9a447ef8693683596a6fc134016\"" /DSQLITE_THREADSAFE=0 /DSQLITE_OMIT_LOAD_EXTENSION=1 /DSQLITE_ENABLE_NORMALIZE /DSQLITE_EXTRA_INIT=core_init /I src/ /I src/sqlite ./dist/sqlite3-extra.c src/sqlite/shell.c src/crsqlite.c src/util.c src/tableinfo.c src/triggers.c src/changes-vtab.c src/changes-vtab-read.c src/changes-vtab-common.c src/changes-vtab-write.c src/ext-data.c src/get-table.c /link /OUT:dist/crsqlite.exe
```