### PR TITLE
Fix valgrind reachable memory error

### DIFF
--- a/.github/workflows/c-valgrind.yaml
+++ b/.github/workflows/c-valgrind.yaml
@@ -26,9 +26,6 @@ jobs:
       - name: Install valgrind
         run: sudo apt install -y valgrind
 
-      # there's always 16 bytes left allocated yet to be tracked down.
-      # this number never goes up no matter how many tests and operations we run
-      # in the process which is the good news.
       - name: Run Valgrind
         run: |
           cd native

--- a/native/src/tests.c
+++ b/native/src/tests.c
@@ -51,4 +51,6 @@ int main(int argc, char *argv[])
   SUITE("vtabwrite") crsqlChangesVtabWriteTestSuite();
   SUITE("vtabcommon") crsqlChangesVtabCommonTestSuite();
   SUITE("extdata") crsqlExtDataTestSuite();
+
+  sqlite3_shutdown();
 }


### PR DESCRIPTION
Registering the extension via `sqlite3_auto_extension()` allocates a buffer for the list of extensions loaded.

This buffer has to be freed via `sqlite3_reset_auto_extension()` which is also called from `sqlite3_shutdown()` and potentially can clean up other resources.

This pr adds a call to `sqlite3_shutdown()` at the end of the test suite to mitigate the valgrind warning.
