### PR TITLE
tie break on value rather than site id

### DIFF
--- a/js/sync-reference/client/src/DB.ts
+++ b/js/sync-reference/client/src/DB.ts
@@ -97,6 +97,8 @@ export class DB {
     seq: [Version, number]
   ): Promise<Changeset[]> {
     logger.info("Pulling changes since ", seq);
+    // pull changes since we last sent the server changes,
+    // excluding what the server has sent us
     const changes = await this.pullChangesetStmt.all(
       BigInt(seq[0]),
       uuidParse(siteId)

--- a/js/sync-reference/server/src/db.ts
+++ b/js/sync-reference/server/src/db.ts
@@ -87,13 +87,16 @@ class DB {
   }
 
   pullChangeset(requestor: SiteIdWire, since: [Version, number]): Changeset[] {
+    // pull changes since the client last saw changes, excluding what the client itself sent us
     const changes = this.#pullChangesetStmt.all(
       BigInt(since[0]),
       uuidParse(requestor)
     );
     changes.forEach((c) => {
-      // idk -- can we not keep this as an array buffer?
-      c[5] = uuidStringify(c[5] as any);
+      // we mask the site ids of clients via the server site id
+      // 1. for privacy
+      // 2. to prevent looping during proxying
+      c[5] = this.siteId;
       // since BigInt doesn't serialize -- convert to string
       c[4] = c[4].toString();
     });

--- a/native/src/changes-vtab-write.h
+++ b/native/src/changes-vtab-write.h
@@ -31,9 +31,8 @@ int crsql_didCidWin(
     const unsigned char *localSiteId,
     const char *insertTbl,
     const char *pkWhereList,
-    const void *insertSiteId,
-    int insertSiteIdLen,
-    const char* colName,
+    const char *colName,
+    const char *sanitizedInsertVal,
     sqlite3_int64 version,
     char **errmsg);
 


### PR DESCRIPTION
fixes #98

Tie braking on value allows the server to mask the site ids of clients.
This is important for privacy / to prevent clients from discovering one another.

This masking also allows us to ensure a client never sends changes it received from a server back to the server, thus starting a loop.

https://user-images.githubusercontent.com/1009003/206575697-90160393-1db7-4ff8-a576-ec3807a65477.mov


