### PR TITLE
Record peer clocks on insert into `crsql_changes`

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -49,7 +49,8 @@ ext_files=src/crsqlite.c \
 	src/changes-vtab-common.c \
 	src/changes-vtab-write.c \
 	src/ext-data.c \
-	src/get-table.c
+	src/get-table.c \
+	src/seen-peers.c
 ext_headers=src/crsqlite.h \
 	src/util.h \
 	src/tableinfo.h \
@@ -58,7 +59,8 @@ ext_headers=src/crsqlite.h \
 	src/changes-vtab-read.h \
 	src/changes-vtab-common.h \
 	src/changes-vtab-write.h \
-	src/ext-data.h
+	src/ext-data.h \
+	src/seen-peers.h
 
 $(prefix):
 	mkdir -p $(prefix)
@@ -77,6 +79,8 @@ sqlite3: $(TARGET_SQLITE3)
 vanilla: $(TARGET_SQLITE3_VANILLA)
 test: $(TARGET_TEST)
 	$(prefix)/test
+# ASAN_OPTIONS=detect_leaks=1
+asan: CC=clang
 asan: $(TARGET_TEST_ASAN)
 	$(TARGET_TEST_ASAN)
 correctness: $(TARGET_LOADABLE) FORCE
@@ -140,7 +144,7 @@ $(TARGET_TEST): $(prefix) $(TARGET_SQLITE3_EXTRA_C) src/tests.c src/*.test.c $(e
 	-o $@
 
 $(TARGET_TEST_ASAN): $(prefix) $(TARGET_SQLITE3_EXTRA_C) src/tests.c src/*.test.c $(ext_files)
-	clang -fsanitize=address -O1 -fno-omit-frame-pointer -Wall \
+	$(CC) -fsanitize=address -g -fno-omit-frame-pointer -Wall \
 	$(DEFINE_SQLITE_PATH) \
 	-DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_LOAD_EXTENSION=1 \
 	-DSQLITE_ENABLE_NORMALIZE \

--- a/core/src/changes-vtab.h
+++ b/core/src/changes-vtab.h
@@ -67,23 +67,6 @@ extern sqlite3_module crsql_changesModule;
  * queries.
  *
  * Per-query data is kept on crsql_Changes_cursor
- *
- * All table infos are fetched on vtab initialization.
- * This creates the constraint that if the schema of a crr
- * is modified after the virtual table definition is loaded
- * then it will not be or not be correctly processed
- * by the virtual table.
- *
- * Given that, if a schema modification is made
- * to a crr table then the changes vtab needs to be
- * reloaded.
- *
- * The simpleset way to accomplish this is to close
- * and re-open the connection responsible for syncing.
- *
- * In practice this should generally not be a problem
- * as application startup would establish, migrated, etc. the schemas
- * after which a sync process would connect.
  */
 typedef struct crsql_Changes_vtab crsql_Changes_vtab;
 struct crsql_Changes_vtab {
@@ -129,7 +112,5 @@ struct crsql_Changes_cursor {
 
   sqlite3_int64 dbVersion;
 };
-
-int crsql_changesTxCommit(sqlite3_vtab *pVTab);
 
 #endif

--- a/core/src/crsqlite.c
+++ b/core/src/crsqlite.c
@@ -74,6 +74,15 @@ static int createSiteIdAndSiteIdTable(sqlite3 *db, unsigned char *ret) {
   return SQLITE_OK;
 }
 
+static int initPeerTrackingTable(sqlite3 *db, char **pzErrMsg) {
+  return sqlite3_exec(
+      db,
+      "CREATE TABLE IF NOT EXISTS __crsql_tracked_peer (\"site_id\" "
+      "BLOB NOT NULL, \"clock\" INTEGER NOT NULL, \"tag\" INTEGER, PRIMARY "
+      "KEY (\"site_id\", \"clock\")) STRICT;",
+      0, 0, pzErrMsg);
+}
+
 /**
  * Loads the siteId into memory. If a site id
  * cannot be found for the given database one is created
@@ -448,6 +457,11 @@ __declspec(dllexport)
   int rc = SQLITE_OK;
 
   SQLITE_EXTENSION_INIT2(pApi);
+
+  rc = initPeerTrackingTable(db, pzErrMsg);
+  if (rc != SQLITE_OK) {
+    return rc;
+  }
 
   crsql_ExtData *pExtData = crsql_newExtData(db);
   if (pExtData == 0) {

--- a/core/src/crsqlite.c
+++ b/core/src/crsqlite.c
@@ -77,9 +77,9 @@ static int createSiteIdAndSiteIdTable(sqlite3 *db, unsigned char *ret) {
 static int initPeerTrackingTable(sqlite3 *db, char **pzErrMsg) {
   return sqlite3_exec(
       db,
-      "CREATE TABLE IF NOT EXISTS __crsql_tracked_peer (\"site_id\" "
+      "CREATE TABLE IF NOT EXISTS crsql_tracked_peers (\"site_id\" "
       "BLOB NOT NULL, \"clock\" INTEGER NOT NULL, \"tag\" INTEGER, PRIMARY "
-      "KEY (\"site_id\", \"clock\")) STRICT;",
+      "KEY (\"site_id\", \"tag\")) STRICT;",
       0, 0, pzErrMsg);
 }
 

--- a/core/src/ext-data.c
+++ b/core/src/ext-data.c
@@ -40,7 +40,7 @@ crsql_ExtData *crsql_newExtData(sqlite3 *db) {
   pExtData->pTrackPeersStmt = 0;
   rc = sqlite3_prepare_v3(
       db,
-      "INSERT INTO __crsql_tracked_peer (\"site_id\", \"clock\", "
+      "INSERT INTO crsql_tracked_peers (\"site_id\", \"clock\", "
       "\"tag\") VALUES (?, ?, ?) ON CONFLICT DO UPDATE SET \"clock\" = "
       "MAX(\"clock\", EXCLUDED.\"clock\")",
       -1, SQLITE_PREPARE_PERSISTENT, &(pExtData->pTrackPeersStmt), 0);

--- a/core/src/ext-data.h
+++ b/core/src/ext-data.h
@@ -24,6 +24,7 @@ struct crsql_ExtData {
   // perma statement -- used to check db schema version
   sqlite3_stmt *pPragmaSchemaVersionStmt;
   sqlite3_stmt *pPragmaDataVersionStmt;
+  sqlite3_stmt *pTrackPeersStmt;
   int pragmaDataVersion;
 
   // this gets set at the start of each transaction on the first invocation

--- a/core/src/seen-peers.c
+++ b/core/src/seen-peers.c
@@ -118,13 +118,13 @@ int crsql_writeTrackedPeers(crsql_SeenPeers *a, crsql_ExtData *pExtData) {
 
     rc = sqlite3_step(pExtData->pTrackPeersStmt);
     if (rc != SQLITE_DONE) {
-      sqlite3_reset(pExtData->pTrackPeersStmt);
       sqlite3_clear_bindings(pExtData->pTrackPeersStmt);
+      sqlite3_reset(pExtData->pTrackPeersStmt);
       return rc;
     }
 
-    rc = sqlite3_reset(pExtData->pTrackPeersStmt);
-    rc += sqlite3_clear_bindings(pExtData->pTrackPeersStmt);
+    rc = sqlite3_clear_bindings(pExtData->pTrackPeersStmt);
+    rc += sqlite3_reset(pExtData->pTrackPeersStmt);
     if (rc != SQLITE_OK) {
       return rc;
     }

--- a/core/src/seen-peers.c
+++ b/core/src/seen-peers.c
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2022 One Law LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tracks what peers we have seen in a transaction against `crsql_changes`
+ *
+ * This is so, at the end of the transaction, we can update clock tables
+ * for the user making network layers simpler to build.
+ */
+
+#include "seen-peers.h"
+
+#include "util.h"
+
+// The assumption for using an array over a hash table is that we generally
+// don't merge changes from many peers all at the same time.
+// TODO: maybe don't even allow this to be growable so we can exit
+// when we hit a use case with too many peers? Hard cap to 25?
+#define INITIAL_SIZE 5
+
+crsql_SeenPeers *crsql_newSeenPeers() {
+  crsql_SeenPeers *ret = sqlite3_malloc(sizeof ret);
+  ret->peers = malloc(INITIAL_SIZE * sizeof(crsql_SeenPeer));
+  ret->len = 0;
+  ret->capacity = INITIAL_SIZE;
+}
+
+int crsql_trackSeenPeer(crsql_SeenPeers *a, const unsigned char *siteId,
+                        int siteIdLen, sqlite3_int64 clock) {
+  // Have we already tacked this peer?
+  // If so, take the max of clock values and return.
+  for (int i = 0; i < a->len; ++i) {
+    if (crsql_siteIdCmp(siteId, siteIdLen, a->peers[i].siteId,
+                        a->peers[i].siteIdLen) == 0) {
+      if (a->peers[i].clock < clock) {
+        a->peers[i].clock = clock;
+      }
+
+      return SQLITE_OK;
+    }
+  }
+
+  // are we at capacity and it is a new peer?
+  // increase our size.
+  if (a->len == a->capacity) {
+    a->capacity *= 2;
+    crsql_SeenPeer *temp =
+        realloc(a->peers, a->capacity * sizeof(crsql_SeenPeer));
+    if (temp == 0) {
+      return SQLITE_ERROR;
+    }
+    a->peers = temp;
+  }
+
+  // assign the peer
+  // the provided `siteId` param is controlled by `sqlite` as an argument to the
+  // insert statement and may not exist on transaction commit if many insert
+  // calls are made against or vtab
+  a->peers[a->len].siteId = sqlite3_malloc(siteIdLen * sizeof(char));
+  memcpy(a->peers[a->len].siteId, siteId, siteIdLen);
+
+  a->len += 1;
+  return SQLITE_OK;
+}
+
+void crsql_resetSeenPeersForTx(crsql_SeenPeers *a) {
+  // free the inner allocations since we'll overwrite those
+  for (int i = 0; i < a->len; ++i) {
+    sqlite3_free(a->peers[i].siteId);
+  }
+
+  // re-wind our length back to 0 for the next transaction
+  // this structure is allocated once per connection and each connection must
+  // only be used from one thread.
+  a->len = 0;
+}
+
+void crsql_freeSeenPeers(crsql_SeenPeers *a) {
+  for (int i = 0; i < a->len; ++i) {
+    sqlite3_free(a->peers[i].siteId);
+  }
+  sqlite3_free(a->peers);
+  sqlite3_free(a);
+}

--- a/core/src/seen-peers.c
+++ b/core/src/seen-peers.c
@@ -110,7 +110,7 @@ int crsql_writeTrackedPeers(crsql_SeenPeers *a, crsql_ExtData *pExtData) {
                            a->peers[i].siteIdLen, SQLITE_STATIC);
     rc += sqlite3_bind_int64(pExtData->pTrackPeersStmt, 2, a->peers[i].clock);
     // TODO: allow tagging of peer tracking for partial db replication
-    rc += sqlite3_bind_null(pExtData->pTrackPeersStmt, 3);
+    rc += sqlite3_bind_int(pExtData->pTrackPeersStmt, 3, 0);
     if (rc != SQLITE_OK) {
       sqlite3_clear_bindings(pExtData->pTrackPeersStmt);
       return rc;

--- a/core/src/seen-peers.h
+++ b/core/src/seen-peers.h
@@ -11,8 +11,8 @@
  * limitations under the License.
  */
 
-#ifndef CRSQLITE_TABLEINFO_H
-#define CRSQLITE_TABLEINFO_H
+#ifndef CRSQLITE_SEEN_PEERS_H
+#define CRSQLITE_SEEN_PEERS_H
 
 #include "sqlite3ext.h"
 SQLITE_EXTENSION_INIT3
@@ -20,10 +20,14 @@ SQLITE_EXTENSION_INIT3
 #include <ctype.h>
 #include <stdlib.h>
 
+#include "ext-data.h"
+
+#define CRSQL_SEEN_PEERS_INITIAL_SIZE 5
+
 typedef struct crsql_SeenPeer crsql_SeenPeer;
 struct crsql_SeenPeer {
   unsigned char *siteId;
-  const int siteIdLen;
+  int siteIdLen;
   sqlite3_int64 clock;
 };
 
@@ -33,5 +37,12 @@ struct crsql_SeenPeers {
   size_t len;
   size_t capacity;
 };
+
+crsql_SeenPeers *crsql_newSeenPeers();
+int crsql_trackSeenPeer(crsql_SeenPeers *a, const unsigned char *siteId,
+                        int siteIdLen, sqlite3_int64 clock);
+void crsql_resetSeenPeersForTx(crsql_SeenPeers *a);
+void crsql_freeSeenPeers(crsql_SeenPeers *a);
+int crsql_writeTrackedPeers(crsql_SeenPeers *a, crsql_ExtData *pExtData);
 
 #endif

--- a/core/src/seen-peers.h
+++ b/core/src/seen-peers.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2022 One Law LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CRSQLITE_TABLEINFO_H
+#define CRSQLITE_TABLEINFO_H
+
+#include "sqlite3ext.h"
+SQLITE_EXTENSION_INIT3
+
+#include <ctype.h>
+
+typedef struct crsql_SeenPeer crsql_SeenPeer;
+struct crsql_SeenPeer {
+  unsigned char *siteId;
+  const int siteIdLen;
+  sqlite3_int64 clock;
+};
+
+typedef struct crsql_SeenPeers crsql_SeenPeers;
+struct crsql_SeenPeers {
+  crsql_SeenPeer *peers;
+  size_t len;
+  size_t capacity;
+};
+
+#endif

--- a/core/src/seen-peers.h
+++ b/core/src/seen-peers.h
@@ -18,6 +18,7 @@
 SQLITE_EXTENSION_INIT3
 
 #include <ctype.h>
+#include <stdlib.h>
 
 typedef struct crsql_SeenPeer crsql_SeenPeer;
 struct crsql_SeenPeer {

--- a/core/src/seen-peers.test.c
+++ b/core/src/seen-peers.test.c
@@ -13,24 +13,134 @@
 
 #include "seen-peers.h"
 
+#include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
-static void testAllocation() {}
+static void testAllocation() {
+  printf("Allocation\n");
+  crsql_SeenPeers *seen = crsql_newSeenPeers();
+  assert(seen->len == 0);
+  assert(seen->capacity == CRSQL_SEEN_PEERS_INITIAL_SIZE);
+  assert(seen->peers != 0);
 
-static void testTrackNewPeer() {}
+  for (int i = 0; i < CRSQL_SEEN_PEERS_INITIAL_SIZE; ++i) {
+    assert(seen->peers[i].clock == 0);
+    assert(seen->peers[i].siteId == 0);
+    assert(seen->peers[i].siteIdLen == 0);
+  }
 
-static void testTrackExistingPeer() {}
+  printf("\t\e[0;32mSuccess\e[0m\n");
 
-static void testArrayGrowth() {}
+  crsql_freeSeenPeers(seen);
+}
 
-static void testReset() {}
+static void testTrackNewPeer() {
+  printf("TrackNewPeer\n");
+  crsql_SeenPeers *seen = crsql_newSeenPeers();
 
-static void testFree() {}
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob", 5, 100);
+  assert(seen->len == 1);
+  assert(seen->peers[0].clock == 100);
+  assert(seen->peers[0].siteIdLen == 5);
+  assert(strcmp((const char *)seen->peers[0].siteId, "blob") == 0);
+  assert(seen->capacity == CRSQL_SEEN_PEERS_INITIAL_SIZE);
+
+  printf("\t\e[0;32mSuccess\e[0m\n");
+  crsql_freeSeenPeers(seen);
+}
+
+static void testTrackExistingPeer() {
+  printf("TrackExistingPeer\n");
+  crsql_SeenPeers *seen = crsql_newSeenPeers();
+
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob", 5, 100);
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob", 5, 200);
+
+  assert(seen->len == 1);
+  assert(seen->peers[0].clock == 200);
+  assert(seen->peers[0].siteIdLen == 5);
+  assert(strcmp((const char *)seen->peers[0].siteId, "blob") == 0);
+  assert(seen->capacity == CRSQL_SEEN_PEERS_INITIAL_SIZE);
+
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob", 5, 2);
+
+  assert(seen->len == 1);
+  assert(seen->peers[0].clock == 200);
+  assert(seen->peers[0].siteIdLen == 5);
+  assert(strcmp((const char *)seen->peers[0].siteId, "blob") == 0);
+  assert(seen->capacity == CRSQL_SEEN_PEERS_INITIAL_SIZE);
+
+  printf("\t\e[0;32mSuccess\e[0m\n");
+  crsql_freeSeenPeers(seen);
+}
+
+static void testArrayGrowth() {
+  printf("ArrayGrowth\n");
+  crsql_SeenPeers *seen = crsql_newSeenPeers();
+
+  for (int i = 0; i < 11; ++i) {
+    char *blob = sqlite3_mprintf("b%d", i);
+    int blobLen = strlen(blob) + 1;
+    crsql_trackSeenPeer(seen, (unsigned char *)blob, blobLen, i);
+    sqlite3_free(blob);
+  }
+
+  assert(seen->capacity == 20);
+  assert(seen->len == 11);
+
+  for (int i = 0; i < 11; ++i) {
+    char *blob = sqlite3_mprintf("b%d", i);
+    int blobLen = strlen(blob) + 1;
+    assert(seen->peers[i].clock == i);
+    assert(seen->peers[i].siteIdLen == blobLen);
+    assert(strcmp((char *)seen->peers[i].siteId, blob) == 0);
+    sqlite3_free(blob);
+  }
+
+  printf("\t\e[0;32mSuccess\e[0m\n");
+  crsql_freeSeenPeers(seen);
+}
+
+static void testReset() {
+  printf("Reset\n");
+  crsql_SeenPeers *seen = crsql_newSeenPeers();
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob1", 6, 100);
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob2", 6, 200);
+
+  crsql_resetSeenPeersForTx(seen);
+  assert(seen->len == 0);
+
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob1", 6, 1);
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob2", 6, 2);
+
+  assert(seen->len == 2);
+  assert(seen->peers[0].clock == 1);
+  assert(seen->peers[1].clock == 2);
+
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob1", 6, 11);
+  crsql_trackSeenPeer(seen, (const unsigned char *)"blob2", 6, 22);
+
+  assert(seen->len == 2);
+  assert(seen->peers[0].clock == 11);
+  assert(seen->peers[1].clock == 22);
+
+  printf("\t\e[0;32mSuccess\e[0m\n");
+  crsql_freeSeenPeers(seen);
+}
+
+// Really only exists for simple valgrind/asan leak tracking
+static void testFree() {
+  printf("Free\n");
+  crsql_SeenPeers *seen = crsql_newSeenPeers();
+  crsql_freeSeenPeers(seen);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
 
 static void testWriteTrackedPeersToDb() {}
 
 void crsqlSeenPeersTestSuite() {
-  printf("\e[47m\e[1;30mSuite: seen_peers\e[0m\n");
+  printf("\e[47m\e[1;30mSuite: seenpeers\e[0m\n");
 
   testAllocation();
   testTrackNewPeer();

--- a/core/src/seen-peers.test.c
+++ b/core/src/seen-peers.test.c
@@ -177,6 +177,7 @@ static void assertWrittenPeers(sqlite3 *db, crsql_SeenPeer *zExpected,
 
   assert(compared == zExpectedLen);
   assert(rc == SQLITE_DONE);
+  sqlite3_finalize(pStmt);
 }
 
 static void testWriteTrackedPeersToDb() {
@@ -231,6 +232,7 @@ static void testWriteTrackedPeersToDb() {
   printf("\t\e[0;32mSuccess\e[0m\n");
   sqlite3_free(expected);
   crsql_freeSeenPeers(seen);
+  crsql_freeExtData(extData);
   crsql_close(db);
 }
 

--- a/core/src/seen-peers.test.c
+++ b/core/src/seen-peers.test.c
@@ -17,6 +17,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "ext-data.h"
+
+int crsql_close(sqlite3 *db);
+
 static void testAllocation() {
   printf("Allocation\n");
   crsql_SeenPeers *seen = crsql_newSeenPeers();
@@ -137,7 +141,98 @@ static void testFree() {
   printf("\t\e[0;32mSuccess\e[0m\n");
 }
 
-static void testWriteTrackedPeersToDb() {}
+static int countTrackedPeers(sqlite3 *db) {
+  sqlite3_stmt *pStmt;
+  int rc = sqlite3_prepare_v2(db, "SELECT count(*) FROM crsql_tracked_peers",
+                              -1, &pStmt, 0);
+  assert(rc == SQLITE_OK);
+
+  rc = sqlite3_step(pStmt);
+  assert(rc == SQLITE_ROW);
+  int ret = sqlite3_column_int(pStmt, 0);
+  sqlite3_finalize(pStmt);
+  return ret;
+}
+
+static void assertWrittenPeers(sqlite3 *db, crsql_SeenPeer *zExpected,
+                               int zExpectedLen) {
+  sqlite3_stmt *pStmt;
+  int rc = sqlite3_prepare_v2(
+      db, "SELECT site_id, clock, tag FROM crsql_tracked_peers", -1, &pStmt, 0);
+  assert(rc == SQLITE_OK);
+
+  int compared = 0;
+  while ((rc = sqlite3_step(pStmt)) == SQLITE_ROW) {
+    assert(compared < zExpectedLen);
+
+    int siteIdLen = sqlite3_column_bytes(pStmt, 0);
+    const char *siteId = (const char *)sqlite3_column_blob(pStmt, 0);
+    int clock = sqlite3_column_int64(pStmt, 1);
+    assert(strcmp((const char *)zExpected[compared].siteId, siteId) == 0);
+    assert(zExpected[compared].clock == clock);
+    assert(zExpected[compared].siteIdLen == siteIdLen);
+
+    compared++;
+  }
+
+  assert(compared == zExpectedLen);
+  assert(rc == SQLITE_DONE);
+}
+
+static void testWriteTrackedPeersToDb() {
+  printf("WriteTrackedPeersToDb");
+  sqlite3 *db;
+  int rc = sqlite3_open(":memory:", &db);
+  assert(rc == SQLITE_OK);
+
+  crsql_SeenPeers *seen = crsql_newSeenPeers();
+  crsql_ExtData *extData = crsql_newExtData(db);
+
+  // writing empty set is a no-op
+  assert(crsql_writeTrackedPeers(seen, extData) == SQLITE_OK);
+  assert(countTrackedPeers(db) == 0);
+
+  crsql_SeenPeer *expected = sqlite3_malloc(2 * sizeof(crsql_SeenPeer));
+  expected[0].siteId = (unsigned char *)"blob1";
+  expected[0].siteIdLen = 6;
+  expected[0].clock = 11;
+  expected[1].siteId = (unsigned char *)"blob2";
+  expected[1].siteIdLen = 6;
+  expected[1].clock = 22;
+
+  // writing a some peers
+  crsql_trackSeenPeer(seen, expected[0].siteId, expected[0].siteIdLen,
+                      expected[0].clock);
+  crsql_trackSeenPeer(seen, expected[1].siteId, expected[1].siteIdLen,
+                      expected[1].clock);
+  assert(crsql_writeTrackedPeers(seen, extData) == SQLITE_OK);
+  assert(countTrackedPeers(db) == 2);
+  assertWrittenPeers(db, expected, 2);
+
+  // we can't run the clocks backwards
+  crsql_resetSeenPeersForTx(seen);
+  crsql_trackSeenPeer(seen, expected[0].siteId, expected[0].siteIdLen, 1);
+  crsql_trackSeenPeer(seen, expected[1].siteId, expected[1].siteIdLen, 2);
+  assert(crsql_writeTrackedPeers(seen, extData) == SQLITE_OK);
+  assert(countTrackedPeers(db) == 2);
+  assertWrittenPeers(db, expected, 2);
+
+  // but can run them forward
+  expected[0].clock = 100;
+  expected[1].clock = 200;
+  crsql_trackSeenPeer(seen, expected[0].siteId, expected[0].siteIdLen,
+                      expected[0].clock);
+  crsql_trackSeenPeer(seen, expected[1].siteId, expected[1].siteIdLen,
+                      expected[1].clock);
+  assert(crsql_writeTrackedPeers(seen, extData) == SQLITE_OK);
+  assert(countTrackedPeers(db) == 2);
+  assertWrittenPeers(db, expected, 2);
+
+  printf("\t\e[0;32mSuccess\e[0m\n");
+  sqlite3_free(expected);
+  crsql_freeSeenPeers(seen);
+  crsql_close(db);
+}
 
 void crsqlSeenPeersTestSuite() {
   printf("\e[47m\e[1;30mSuite: seenpeers\e[0m\n");

--- a/core/src/seen-peers.test.c
+++ b/core/src/seen-peers.test.c
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2022 One Law LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "seen-peers.h"
+
+#include <stdio.h>
+
+static void testAllocation() {}
+
+static void testTrackNewPeer() {}
+
+static void testTrackExistingPeer() {}
+
+static void testArrayGrowth() {}
+
+static void testReset() {}
+
+static void testFree() {}
+
+static void testWriteTrackedPeersToDb() {}
+
+void crsqlSeenPeersTestSuite() {
+  printf("\e[47m\e[1;30mSuite: seen_peers\e[0m\n");
+
+  testAllocation();
+  testTrackNewPeer();
+  testTrackExistingPeer();
+  testArrayGrowth();
+  testReset();
+  testFree();
+  testWriteTrackedPeersToDb();
+}

--- a/core/src/tableinfo.c
+++ b/core/src/tableinfo.c
@@ -15,7 +15,6 @@
 
 #include <assert.h>
 #include <ctype.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/core/src/tests.c
+++ b/core/src/tests.c
@@ -35,6 +35,7 @@ void crsqlChangesVtabTestSuite();
 void crsqlChangesVtabWriteTestSuite();
 void crsqlChangesVtabCommonTestSuite();
 void crsqlExtDataTestSuite();
+void crsqlSeenPeersTestSuite();
 
 int main(int argc, char *argv[]) {
   char *suite = "all";
@@ -50,6 +51,7 @@ int main(int argc, char *argv[]) {
   SUITE("vtabwrite") crsqlChangesVtabWriteTestSuite();
   SUITE("vtabcommon") crsqlChangesVtabCommonTestSuite();
   SUITE("extdata") crsqlExtDataTestSuite();
+  SUITE("seenpeers") crsqlSeenPeersTestSuite();
   // integration tests should come at the end given fixing unit tests will
   // likely fix integration tests
   SUITE("crsql") crsqlTestSuite();

--- a/core/src/triggers.c
+++ b/core/src/triggers.c
@@ -14,7 +14,6 @@
 #include "triggers.h"
 
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 #include "consts.h"


### PR DESCRIPTION
This updates `crsql_changes` to record the clocks of peers seen during the insert.

Automatically tracking peer clocks + creating a table to track clocks makes the authoring of networking layers simpler. The authors don't need to track peer clocks on their own.

As an optimization, however, they may still wish to track clocks internally. That optimization would be to enable streaming of changes before having those changes acknowledge and committed by peers.