### PR TITLE
track max clock values we see for peers on insert to `crsql_changes`

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -40,6 +40,8 @@ TARGET_TEST=$(prefix)/test
 TARGET_FUZZ=$(prefix)/fuzz
 TARGET_TEST_ASAN=$(prefix)/test-asan
 
+
+# js/browser/wa-sqlite/Makefile, deps/sqlite/GNUMakefile, core/binding.gyp, core/Makefile
 ext_files=src/crsqlite.c \
 	src/util.c \
 	src/tableinfo.c \

--- a/core/binding.gyp
+++ b/core/binding.gyp
@@ -73,6 +73,7 @@
         './src/changes-vtab-write.c',
         './src/ext-data.c',
         './src/get-table.c',
+        './src/seen-peers.c',
       ],
       'include_dirs': [
         './src',

--- a/core/package.json
+++ b/core/package.json
@@ -25,7 +25,8 @@
     "build-debug": "node-gyp rebuild --debug",
     "rebuild-release": "pnpm run build-release",
     "rebuild-debug": "pnpm run build-debug",
-    "test": "make test"
+    "test": "make test",
+    "deep-clean": "rm -rf ./build || true && rm -rf dist || true"
   },
   "license": "Apache 2",
   "keywords": [

--- a/core/src/changes-vtab-write.c
+++ b/core/src/changes-vtab-write.c
@@ -20,6 +20,7 @@
 #include "consts.h"
 #include "crsqlite.h"
 #include "ext-data.h"
+#include "seen-peers.h"
 #include "tableinfo.h"
 #include "util.h"
 
@@ -294,6 +295,9 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
   crsql_TableInfo *tblInfo = crsql_findTableInfo(pTab->pExtData->zpTableInfos,
                                                  pTab->pExtData->tableInfosLen,
                                                  (const char *)insertTbl);
+
+  crsql_trackSeenPeer(pTab->pSeenPeers, insertSiteId, insertSiteIdLen,
+                      insertDbVrsn);
   if (tblInfo == 0) {
     *errmsg = sqlite3_mprintf(
         "crsql - could not find the schema information for table %s",

--- a/core/src/changes-vtab.h
+++ b/core/src/changes-vtab.h
@@ -58,6 +58,7 @@ SQLITE_EXTENSION_INIT3
 
 #include "crsqlite.h"
 #include "ext-data.h"
+#include "seen-peers.h"
 #include "tableinfo.h"
 
 extern sqlite3_module crsql_changesModule;
@@ -73,6 +74,7 @@ struct crsql_Changes_vtab {
   sqlite3_vtab base;
   sqlite3 *db;
 
+  crsql_SeenPeers *pSeenPeers;
   crsql_ExtData *pExtData;
 };
 

--- a/core/src/seen-peers.c
+++ b/core/src/seen-peers.c
@@ -87,7 +87,7 @@ int crsql_trackSeenPeer(crsql_SeenPeers *a, const unsigned char *siteId,
   return SQLITE_OK;
 }
 
-void crsql_resetSeenPeersForTx(crsql_SeenPeers *a) {
+void crsql_resetSeenPeers(crsql_SeenPeers *a) {
   // free the inner allocations since we'll overwrite those
   for (int i = 0; i < a->len; ++i) {
     sqlite3_free(a->peers[i].siteId);

--- a/core/src/seen-peers.h
+++ b/core/src/seen-peers.h
@@ -41,7 +41,7 @@ struct crsql_SeenPeers {
 crsql_SeenPeers *crsql_newSeenPeers();
 int crsql_trackSeenPeer(crsql_SeenPeers *a, const unsigned char *siteId,
                         int siteIdLen, sqlite3_int64 clock);
-void crsql_resetSeenPeersForTx(crsql_SeenPeers *a);
+void crsql_resetSeenPeers(crsql_SeenPeers *a);
 void crsql_freeSeenPeers(crsql_SeenPeers *a);
 int crsql_writeTrackedPeers(crsql_SeenPeers *a, crsql_ExtData *pExtData);
 

--- a/core/src/seen-peers.test.c
+++ b/core/src/seen-peers.test.c
@@ -112,7 +112,7 @@ static void testReset() {
   crsql_trackSeenPeer(seen, (const unsigned char *)"blob1", 6, 100);
   crsql_trackSeenPeer(seen, (const unsigned char *)"blob2", 6, 200);
 
-  crsql_resetSeenPeersForTx(seen);
+  crsql_resetSeenPeers(seen);
   assert(seen->len == 0);
 
   crsql_trackSeenPeer(seen, (const unsigned char *)"blob1", 6, 1);
@@ -211,7 +211,7 @@ static void testWriteTrackedPeersToDb() {
   assertWrittenPeers(db, expected, 2);
 
   // we can't run the clocks backwards
-  crsql_resetSeenPeersForTx(seen);
+  crsql_resetSeenPeers(seen);
   crsql_trackSeenPeer(seen, expected[0].siteId, expected[0].siteIdLen, 1);
   crsql_trackSeenPeer(seen, expected[1].siteId, expected[1].siteIdLen, 2);
   assert(crsql_writeTrackedPeers(seen, extData) == SQLITE_OK);


### PR DESCRIPTION
Simplifies writing of networking layers.

See latest docs -- https://vlcn.io/docs/guide-sync#using-tracked-peers