### PR TITLE
Run valgrind against Rust integration tests

### DIFF
--- a/.github/workflows/rs-valgrind.yml
+++ b/.github/workflows/rs-valgrind.yml
@@ -1,0 +1,46 @@
+on:
+  push:
+  pull_request:
+name: "rs-valgrind"
+jobs:
+  build:
+    name: Testing on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2
+        with:
+          path: ./
+          load-mode: strict
+
+      - name: Rust Nightly
+        run: |
+          rustup default nightly
+          rustup update
+
+      - name: Install Valgrind
+        run: |
+          cargo install cargo-valgrind
+
+      - name: Test Automigrate
+        run: |
+          cd core/rs/automigrate-core
+          cargo valgrind test --features=loadable_extension
+
+      - name: Test Fractindex
+        run: |
+          cd core/rs/fractindex-core
+          cargo valgrind test --features=loadable_extension
+
+      - name: Integration Tests
+        run: |
+          cd core/rs/integration-check
+          cargo valgrind test

--- a/.github/workflows/rs-valgrind.yml
+++ b/.github/workflows/rs-valgrind.yml
@@ -26,7 +26,10 @@ jobs:
           rustup default nightly
           rustup update
 
-      - name: Install Valgrind
+      - name: Install valgrind
+        run: sudo apt install -y valgrind
+
+      - name: Install Cargo Valgrind
         run: |
           cargo install cargo-valgrind
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/sqlite-no_std"]
 	path = core/rs/sqlite-rs-embedded
-	url = https://github.com/vlcn-io/sqlite-no_std
+	url = git@github.com:vlcn-io/sqlite-rs-embedded.git
 [submodule "js/deps/emsdk"]
 	path = js/deps/emsdk
 	url = git@github.com:emscripten-core/emsdk.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,5 @@
 [submodule "js/deps/wa-sqlite"]
 	path = js/deps/wa-sqlite
 	url = git@github.com:vlcn-io/wa-sqlite.git
+[submodule "sqlite-rs-embedded"]
+	url = git@github.com:vlcn-io/sqlite-rs-embedded.git

--- a/core/rs/automigrate-core/src/automigrate.rs
+++ b/core/rs/automigrate-core/src/automigrate.rs
@@ -24,24 +24,7 @@ pub extern "C" fn crsql_automigrate(
         return;
     }
 
-    // let schema = args[0].text();
-
-    // let schema_version = pull_schema_version(schema);
-    let db = sqlite::open(sqlite::strlit!(":memory:"));
-    if !db.is_ok() {
-        ctx.result_error(
-            "failed to open the in-memory db required to calculate schema modifications",
-        );
-        return;
-    }
-
-    let stmt = db
-        .unwrap()
-        .prepare_v2("SELECT count(*) FROM pragma_function_list WHERE name = 'crsql_automigrate';")
-        .unwrap();
-    stmt.step().unwrap();
-    let name = stmt.column_text(0).unwrap();
-    ctx.result_text_transient(name);
+    ctx.result_text_transient("fii");
     // let db = db.unwrap();
 
     /*

--- a/core/rs/integration-check/tests/automigrate.rs
+++ b/core/rs/integration-check/tests/automigrate.rs
@@ -28,6 +28,6 @@ fn invoke_automigrate_impl() -> Result<(), ResultCode> {
     stmt.step()?;
     let text = stmt.column_text(0)?;
     println!("text: {:?}", text);
-    integration_utils::closedb(db)?;
+    integration_utils::closedb(&db)?;
     Ok(())
 }

--- a/core/rs/integration-check/tests/backfill.rs
+++ b/core/rs/integration-check/tests/backfill.rs
@@ -50,7 +50,7 @@ fn new_empty_table_impl() -> Result<(), ResultCode> {
     db.exec_safe("CREATE TABLE foo (id PRIMARY KEY, name);")?;
     db.exec_safe("SELECT crsql_as_crr('foo');")?;
     db.exec_safe("SELECT * FROM foo__crsql_clock;")?;
-    integration_utils::closedb(db)
+    integration_utils::closedb(&db)
 }
 
 fn new_nonempty_table_impl(apply_twice: bool) -> Result<(), ResultCode> {
@@ -93,7 +93,7 @@ fn new_nonempty_table_impl(apply_twice: bool) -> Result<(), ResultCode> {
         assert_eq!(stmt.column_int64(5)?, 1); // db version
     }
     assert_eq!(cnt, 2);
-    integration_utils::closedb(db)
+    integration_utils::closedb(&db)
 }
 
 fn reapplied_empty_table_impl() -> Result<(), ResultCode> {
@@ -104,5 +104,5 @@ fn reapplied_empty_table_impl() -> Result<(), ResultCode> {
     db.exec_safe("SELECT * FROM foo__crsql_clock;")?;
     db.exec_safe("SELECT crsql_as_crr('foo');")?;
     db.exec_safe("SELECT * FROM foo__crsql_clock;")?;
-    integration_utils::closedb(db)
+    integration_utils::closedb(&db)
 }

--- a/core/rs/integration-check/tests/pk_only_tables.rs
+++ b/core/rs/integration-check/tests/pk_only_tables.rs
@@ -124,7 +124,7 @@ fn create_pkonlytable_impl() -> Result<(), ResultCode> {
     let db_a = integration_utils::opendb()?;
 
     setup_schema(&db_a)?;
-    integration_utils::closedb(db_a)?;
+    integration_utils::closedb(&db_a)?;
     Ok(())
 }
 
@@ -158,8 +158,8 @@ fn insert_pkonly_row_impl() -> Result<(), ResultCode> {
     let result = stmt.step()?;
     assert_eq!(result, ResultCode::DONE);
 
-    integration_utils::closedb(db_a)?;
-    integration_utils::closedb(db_b)?;
+    integration_utils::closedb(&db_a)?;
+    integration_utils::closedb(&db_b)?;
     Ok(())
 }
 
@@ -191,8 +191,8 @@ fn modify_pkonly_row_impl() -> Result<(), ResultCode> {
     let result = stmt.step()?;
     assert_eq!(result, ResultCode::DONE);
 
-    integration_utils::closedb(db_a)?;
-    integration_utils::closedb(db_b)?;
+    integration_utils::closedb(&db_a)?;
+    integration_utils::closedb(&db_b)?;
     Ok(())
 }
 
@@ -258,8 +258,8 @@ fn junction_table_impl() -> Result<(), ResultCode> {
     // delete the edge
     // check it
 
-    integration_utils::closedb(db_a)?;
-    integration_utils::closedb(db_b)?;
+    integration_utils::closedb(&db_a)?;
+    integration_utils::closedb(&db_b)?;
     Ok(())
 }
 
@@ -288,6 +288,6 @@ fn discord_report_1_impl() -> Result<(), ResultCode> {
 
     assert_eq!(stmt.step()?, ResultCode::DONE);
 
-    integration_utils::closedb(db_a)?;
+    integration_utils::closedb(&db_a)?;
     Ok(())
 }

--- a/core/rs/integration-check/tests/teardown.rs
+++ b/core/rs/integration-check/tests/teardown.rs
@@ -30,5 +30,5 @@ fn tear_down_impl() -> Result<(), ResultCode> {
     stmt.step()?;
     let count = stmt.column_int(0)?;
     assert!(count == 0);
-    integration_utils::closedb(db)
+    integration_utils::closedb(&db)
 }

--- a/core/rs/integration-utils/src/lib.rs
+++ b/core/rs/integration-utils/src/lib.rs
@@ -29,8 +29,7 @@ macro_rules! counter_setup {
         static COUNTER: AtomicUsize = AtomicUsize::new($count);
 
         fn decrement_counter() {
-            COUNTER.fetch_sub(1, Ordering::SeqCst);
-            if COUNTER.load(Ordering::SeqCst) == 0 {
+            if COUNTER.fetch_sub(1, Ordering::SeqCst) == 1 {
                 sqlite::shutdown();
             }
         }

--- a/core/rs/integration-utils/src/lib.rs
+++ b/core/rs/integration-utils/src/lib.rs
@@ -9,7 +9,7 @@ pub fn opendb() -> Result<ManagedConnection, ResultCode> {
     Ok(connection)
 }
 
-pub fn closedb(db: ManagedConnection) -> Result<(), ResultCode> {
+pub fn closedb(db: &ManagedConnection) -> Result<(), ResultCode> {
     db.exec_safe("SELECT crsql_finalize()")?;
     // no close, close gets called on drop.
     Ok(())


### PR DESCRIPTION
given rust is not immune to memory leaks -- esp when interfacing with C.

Case and point, this leak which was uncovered: https://github.com/vlcn-io/cr-sqlite/pull/171/commits/26b01512869426d773c0cf4503075b7dbd183aa1

> calling closedb gave ownership of the DB to closedb. Closedb would then try dropping the DB on return.
> Statements were not yet finalized so this drop attempt would fail and not reclaim memory.