### PR TITLE
Less floating promises

### DIFF
--- a/js/packages/p2p/src/WholeDbReplicator.ts
+++ b/js/packages/p2p/src/WholeDbReplicator.ts
@@ -268,7 +268,7 @@ export class WholeDbReplicator {
         console.error(e);
         throw e;
       } finally {
-        stmt.finalize(tx);
+        await stmt.finalize(tx);
       }
 
       await tx.exec(


### PR DESCRIPTION
When I was playing around with the p2p package, eslint told me there were a few [floating promises](https://typescript-eslint.io/rules/no-floating-promises/). This PR fixes two that don't cause externally visible changes, but there are a few others that would involve function signature changes, namely [in the dispose](https://github.com/vlcn-io/cr-sqlite/blob/main/js/packages/p2p/src/WholeDbReplicator.ts#L133), [newConnection](https://github.com/vlcn-io/cr-sqlite/blob/main/js/packages/p2p/src/WholeDbReplicator.ts#L224), and in [schemaChanged](https://github.com/vlcn-io/cr-sqlite/blob/main/js/packages/p2p/src/WholeDbRtc.ts#L74). I'm not nearly experienced enough in JavaScript (or websockets) to know if changing those (or even this PR) is a good idea.