### PR TITLE
Support all the expected filters against `crsql_changes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ The full documentation site is available [here](https://vlcn.io/docs/getting-sta
 - A function extension (`crsql_as_crr`) to upgrade existing tables to "crrs" or "conflict free replicated relations"
   - `SELECT crsql_as_crr('table_name')`
 - A virtual table (`crsql_changes`) to ask the database for changesets or to apply changesets from another database
-  - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id IS NULL` -- to get local changes
-  - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id IS NOT some_site` -- to get all changes excluding those synced from some site
+  - `SELECT "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_siteid()) FROM crsql_changes WHERE db_version > x AND site_id IS NULL` -- to get local changes
+  - `SELECT "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_siteid()) FROM crsql_changes WHERE db_version > x AND site_id IS NOT some_site` -- to get all changes excluding those synced from some site
   - `INSERT INTO crsql_changes VALUES ([patches receied from select on another peer])`
 - And `crsql_alter_begin('table_name')` & `crsql_alter_commit('table_name')` primitives to allow altering table definitions that have been upgraded to `crr`s.
   - Until we move forward with extending the syntax of SQLite to be CRR aware, altering CRRs looks like:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ In other words, you can write to your SQLite database while offline. I can write
 All of the above involve a merging of independent edits problem. If your database can handle this for you, you don't need custom code in your application to handle those 5 cases.
 
 Discussions of these problems in the application space:
+
 - [Meta Muse](https://museapp.com/podcast/56-sync/)
 - [FB Messenger re-write](https://softwareengineeringdaily.com/2020/03/31/facebook-messenger-engineering-with-mohsen-agsen/)
 
@@ -48,7 +49,7 @@ The full documentation site is available [here](https://vlcn.io/docs/getting-sta
   - `SELECT crsql_as_crr('table_name')`
 - A virtual table (`crsql_changes`) to ask the database for changesets or to apply changesets from another database
   - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id IS NULL` -- to get local changes
-  - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id != some_site` -- to get all changes excluding those synced from some site
+  - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id IS NOT some_site` -- to get all changes excluding those synced from some site
   - `INSERT INTO crsql_changes VALUES ([patches receied from select on another peer])`
 - And `crsql_alter_begin('table_name')` & `crsql_alter_commit('table_name')` primitives to allow altering table definitions that have been upgraded to `crr`s.
   - Until we move forward with extending the syntax of SQLite to be CRR aware, altering CRRs looks like:
@@ -291,7 +292,6 @@ JS APIs for using `cr-sqlite` in the browser are not yet documented but exist in
 
 - [Observable Notebook](https://observablehq.com/@tantaman/cr-sqlite-basic-setup)
 - https://github.com/vlcn-io/live-examples
-
 
 # Research & Prior Art
 

--- a/core/README.md
+++ b/core/README.md
@@ -49,7 +49,7 @@ The full documentation site is available [here](https://vlcn.io/docs/getting-sta
   - `SELECT crsql_as_crr('table_name')`
 - A virtual table (`crsql_changes`) to ask the database for changesets or to apply changesets from another database
   - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id IS NULL` -- to get local changes
-  - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id != some_site` -- to get all changes excluding those synced from some site
+  - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id IS NOT some_site` -- to get all changes excluding those synced from some site
   - `INSERT INTO crsql_changes VALUES ([patches receied from select on another peer])`
 - And `crsql_alter_begin('table_name')` & `crsql_alter_commit('table_name')` primitives to allow altering table definitions that have been upgraded to `crr`s.
   - Until we move forward with extending the syntax of SQLite to be CRR aware, altering CRRs looks like:

--- a/core/src/changes-vtab-read.c
+++ b/core/src/changes-vtab-read.c
@@ -23,7 +23,8 @@ char *crsql_changesQueryForTable(crsql_TableInfo *tableInfo) {
       __crsql_db_version as db_vrsn,\
       __crsql_site_id as site_id\
     FROM \"%s__crsql_clock\"",
-      tableInfo->tblName, crsql_quoteConcat(tableInfo->pks, tableInfo->pksLen));
+      tableInfo->tblName, crsql_quoteConcat(tableInfo->pks, tableInfo->pksLen),
+      tableInfo->tblName);
 
   return zSql;
 }

--- a/core/src/changes-vtab-read.c
+++ b/core/src/changes-vtab-read.c
@@ -74,7 +74,8 @@ char *crsql_changesUnionQuery(crsql_TableInfo **tableInfos, int tableInfosLen,
       "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (%z) %s%s ORDER "
       "BY "
       "db_vrsn, tbl ASC",
-      unionsStr, strlen(idxStr) > 0 ? "WHERE " : "", idxStr);
+      unionsStr, idxStr != 0 && strlen(idxStr) > 0 ? "WHERE " : "",
+      idxStr == 0 ? "" : idxStr);
   // %z frees unionsStr https://www.sqlite.org/printf.html#percentz
 }
 

--- a/core/src/changes-vtab-read.h
+++ b/core/src/changes-vtab-read.h
@@ -7,7 +7,7 @@ SQLITE_EXTENSION_INIT3
 #include "changes-vtab-common.h"
 #include "tableinfo.h"
 
-char *crsql_changesQueryForTable(crsql_TableInfo *tableInfo, int idxNum);
+char *crsql_changesQueryForTable(crsql_TableInfo *tableInfo);
 
 #define TBL 0
 #define PKS 1
@@ -16,7 +16,7 @@ char *crsql_changesQueryForTable(crsql_TableInfo *tableInfo, int idxNum);
 #define DB_VRSN 4
 #define SITE_ID 5
 char *crsql_changesUnionQuery(crsql_TableInfo **tableInfos, int tableInfosLen,
-                              int idxNum);
+                              const char *idxStr);
 char *crsql_rowPatchDataQuery(sqlite3 *db, crsql_TableInfo *tblInfo,
                               const char *colName, const char *pks);
 

--- a/core/src/changes-vtab-read.test.c
+++ b/core/src/changes-vtab-read.test.c
@@ -23,7 +23,7 @@ static void testChangesQueryForTable() {
   rc += crsql_getTableInfo(db, "foo", &tblInfo, &err);
   assert(rc == SQLITE_OK);
 
-  char *query = crsql_changesQueryForTable(tblInfo, 6);
+  char *query = crsql_changesQueryForTable(tblInfo);
 
   assert(strcmp(query,
                 "SELECT      \'foo\' as tbl,      quote(\"a\") as pks,      "
@@ -33,7 +33,7 @@ static void testChangesQueryForTable() {
                 "WHERE      site_id IS NOT ?    AND      db_vrsn > ?") == 0);
   sqlite3_free(query);
 
-  query = crsql_changesQueryForTable(tblInfo, 8);
+  query = crsql_changesQueryForTable(tblInfo);
   assert(strcmp(query,
                 "SELECT      \'foo\' as tbl,      quote(\"a\") as pks,      "
                 "__crsql_col_name as cid,      __crsql_col_version as "
@@ -68,7 +68,7 @@ static void testChangesUnionQuery() {
   rc += crsql_getTableInfo(db, "bar", &tblInfos[1], &err);
   assert(rc == SQLITE_OK);
 
-  char *query = crsql_changesUnionQuery(tblInfos, 2, 6);
+  char *query = crsql_changesUnionQuery(tblInfos, 2, "");
   assert(
       strcmp(
           query,
@@ -84,7 +84,7 @@ static void testChangesUnionQuery() {
           "NOT ?    AND      db_vrsn > ?) ORDER BY db_vrsn, tbl ASC") == 0);
   sqlite3_free(query);
 
-  query = crsql_changesUnionQuery(tblInfos, 2, 8);
+  query = crsql_changesUnionQuery(tblInfos, 2, "");
   assert(
       strcmp(
           query,

--- a/core/src/changes-vtab-read.test.c
+++ b/core/src/changes-vtab-read.test.c
@@ -29,17 +29,8 @@ static void testChangesQueryForTable() {
                 "SELECT      \'foo\' as tbl,      quote(\"a\") as pks,      "
                 "__crsql_col_name as cid,      __crsql_col_version as "
                 "col_vrsn,      __crsql_db_version as db_vrsn,      "
-                "__crsql_site_id as site_id    FROM \"foo__crsql_clock\"    "
-                "WHERE      site_id IS NOT ?    AND      db_vrsn > ?") == 0);
-  sqlite3_free(query);
-
-  query = crsql_changesQueryForTable(tblInfo);
-  assert(strcmp(query,
-                "SELECT      \'foo\' as tbl,      quote(\"a\") as pks,      "
-                "__crsql_col_name as cid,      __crsql_col_version as "
-                "col_vrsn,      __crsql_db_version as db_vrsn,      "
-                "__crsql_site_id as site_id    FROM \"foo__crsql_clock\"    "
-                "WHERE      site_id IS  ?    AND      db_vrsn > ?") == 0);
+                "__crsql_site_id as site_id    FROM \"foo__crsql_clock\"") ==
+         0);
   sqlite3_free(query);
 
   printf("\t\e[0;32mSuccess\e[0m\n");
@@ -70,34 +61,32 @@ static void testChangesUnionQuery() {
 
   char *query = crsql_changesUnionQuery(tblInfos, 2, "");
   assert(
-      strcmp(
-          query,
-          "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (SELECT      "
-          "\'foo\' as tbl,      quote(\"a\") as pks,      __crsql_col_name as "
-          "cid,      __crsql_col_version as col_vrsn,      __crsql_db_version "
-          "as db_vrsn,      __crsql_site_id as site_id    FROM "
-          "\"foo__crsql_clock\"    WHERE      site_id IS NOT ?    AND      "
-          "db_vrsn > ? UNION SELECT      \'bar\' as tbl,      quote(\"x\") as "
-          "pks,      __crsql_col_name as cid,      __crsql_col_version as "
-          "col_vrsn,      __crsql_db_version as db_vrsn,      __crsql_site_id "
-          "as site_id    FROM \"bar__crsql_clock\"    WHERE      site_id IS "
-          "NOT ?    AND      db_vrsn > ?) ORDER BY db_vrsn, tbl ASC") == 0);
+      strcmp(query,
+             "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (SELECT    "
+             "  'foo' as tbl,      quote(\"a\") as pks,      __crsql_col_name "
+             "as cid,      __crsql_col_version as col_vrsn,      "
+             "__crsql_db_version as db_vrsn,      __crsql_site_id as site_id   "
+             " FROM \"foo__crsql_clock\" UNION SELECT      'bar' as tbl,      "
+             "quote(\"x\") as pks,      __crsql_col_name as cid,      "
+             "__crsql_col_version as col_vrsn,      __crsql_db_version as "
+             "db_vrsn,      __crsql_site_id as site_id    FROM "
+             "\"bar__crsql_clock\")  ORDER BY db_vrsn, tbl ASC") == 0);
   sqlite3_free(query);
 
-  query = crsql_changesUnionQuery(tblInfos, 2, "");
+  query = crsql_changesUnionQuery(tblInfos, 2, "site_id IS ? AND db_vrsn > ?");
+  printf("\tquery: %s\n", query);
   assert(
-      strcmp(
-          query,
-          "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (SELECT      "
-          "\'foo\' as tbl,      quote(\"a\") as pks,      __crsql_col_name as "
-          "cid,      __crsql_col_version as col_vrsn,      __crsql_db_version "
-          "as db_vrsn,      __crsql_site_id as site_id    FROM "
-          "\"foo__crsql_clock\"    WHERE      site_id IS  ?    AND      "
-          "db_vrsn > ? UNION SELECT      \'bar\' as tbl,      quote(\"x\") as "
-          "pks,      __crsql_col_name as cid,      __crsql_col_version as "
-          "col_vrsn,      __crsql_db_version as db_vrsn,      __crsql_site_id "
-          "as site_id    FROM \"bar__crsql_clock\"    WHERE      site_id IS  ? "
-          "   AND      db_vrsn > ?) ORDER BY db_vrsn, tbl ASC") == 0);
+      strcmp(query,
+             "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (SELECT    "
+             "  'foo' as tbl,      quote(\"a\") as pks,      __crsql_col_name "
+             "as cid,      __crsql_col_version as col_vrsn,      "
+             "__crsql_db_version as db_vrsn,      __crsql_site_id as site_id   "
+             " FROM \"foo__crsql_clock\" UNION SELECT      'bar' as tbl,      "
+             "quote(\"x\") as pks,      __crsql_col_name as cid,      "
+             "__crsql_col_version as col_vrsn,      __crsql_db_version as "
+             "db_vrsn,      __crsql_site_id as site_id    FROM "
+             "\"bar__crsql_clock\") WHERE site_id IS ? AND db_vrsn > ? ORDER "
+             "BY db_vrsn, tbl ASC") == 0);
   sqlite3_free(query);
 
   printf("\t\e[0;32mSuccess\e[0m\n");

--- a/core/src/changes-vtab-read.test.c
+++ b/core/src/changes-vtab-read.test.c
@@ -74,7 +74,6 @@ static void testChangesUnionQuery() {
   sqlite3_free(query);
 
   query = crsql_changesUnionQuery(tblInfos, 2, "site_id IS ? AND db_vrsn > ?");
-  printf("\tquery: %s\n", query);
   assert(
       strcmp(query,
              "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (SELECT    "

--- a/core/src/changes-vtab.c
+++ b/core/src/changes-vtab.c
@@ -461,19 +461,18 @@ static int changesBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
         // the clock table has pks split out.
         break;
       case CHANGES_SINCE_VTAB_CID:
-        constraint = "__crsql_col_id";
+        constraint = "cid";
         break;
       case CHANGES_SINCE_VTAB_CVAL:
-        constraint = "__crsql_col_val";
         break;
       case CHANGES_SINCE_VTAB_COL_VRSN:
-        constraint = "__crsql_col_version";
+        constraint = "col_vrsn";
         break;
       case CHANGES_SINCE_VTAB_DB_VRSN:
-        constraint = "__crsql_db_version";
+        constraint = "db_vrsn";
         break;
       case CHANGES_SINCE_VTAB_SITE_ID:
-        constraint = "__crsql_site_id";
+        constraint = "site_id";
         break;
     }
 

--- a/core/src/changes-vtab.c
+++ b/core/src/changes-vtab.c
@@ -428,46 +428,67 @@ static int changesFilter(sqlite3_vtab_cursor *pVtabCursor, int idxNum,
 */
 static int changesBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
   int idxNum = 0;
-  int versionIdx = -1;
-  int requestorIdx = -1;
 
+  crsql_Changes_vtab *crsqlTab = (crsql_Changes_vtab *)tab;
+  sqlite3_str *pStr = sqlite3_str_new(crsqlTab->db);
+
+  int firstConstaint = 1;
+  char *constraint = 0;
+  int argvIndex = 1;
   for (int i = 0; i < pIdxInfo->nConstraint; i++) {
     const struct sqlite3_index_constraint *pConstraint =
         &pIdxInfo->aConstraint[i];
     switch (pConstraint->iColumn) {
+      case CHANGES_SINCE_VTAB_TBL:
+        // TODO: stick tbl constraint into pTab?
+        // to read out later?
+        break;
+      case CHANGES_SINCE_VTAB_PK:
+        // TODO: bind param it? o wait, it would need splitting.
+        // the clock table has pks split out.
+        break;
+      case CHANGES_SINCE_VTAB_CID:
+        constraint = "__crsql_col_id";
+        break;
+      case CHANGES_SINCE_VTAB_CVAL:
+        constraint = "__crsql_col_val";
+        break;
+      case CHANGES_SINCE_VTAB_COL_VRSN:
+        constraint = "__crsql_col_version";
+        break;
       case CHANGES_SINCE_VTAB_DB_VRSN:
-        if (pConstraint->op != SQLITE_INDEX_CONSTRAINT_GT) {
-          tab->zErrMsg = sqlite3_mprintf(
-              "crsql_changes.version only supports the greater than "
-              "operator. "
-              "E.g., version > x");
-          return SQLITE_CONSTRAINT;
-        }
-        versionIdx = i;
+        constraint = "__crsql_db_version";
+        break;
+      case CHANGES_SINCE_VTAB_SITE_ID:
+        constraint = "__crsql_site_id";
+        break;
+    }
+
+    if (constraint != 0) {
+      const char *opString = getOperatorString(pConstraint->op);
+      if (opString == 0) {
+        continue;
+      }
+      if (firstConstaint) {
+        firstConstaint = 0;
+      } else {
+        sqlite3_str_append(pStr, " AND ", -1);
+      }
+      sqlite3_str_appendf(pStr, "%s %s ?", constraint, opString);
+      constraint = 0;
+      pIdxInfo->aConstraintUsage[i].argvIndex = argvIndex;
+      pIdxInfo->aConstraintUsage[i].omit = 1;
+      argvIndex += 1;
+    }
+
+    const struct sqlite3_index_constraint *pConstraint =
+        &pIdxInfo->aConstraint[i];
+    switch (pConstraint->iColumn) {
+      case CHANGES_SINCE_VTAB_DB_VRSN:
         idxNum |= 2;
         break;
       case CHANGES_SINCE_VTAB_SITE_ID:
-        if (pConstraint->op != SQLITE_INDEX_CONSTRAINT_NE &&
-            pConstraint->op != SQLITE_INDEX_CONSTRAINT_ISNOT &&
-            pConstraint->op != SQLITE_INDEX_CONSTRAINT_EQ &&
-            pConstraint->op != SQLITE_INDEX_CONSTRAINT_IS &&
-            pConstraint->op != SQLITE_INDEX_CONSTRAINT_ISNOTNULL &&
-            pConstraint->op != SQLITE_INDEX_CONSTRAINT_ISNULL) {
-          tab->zErrMsg = sqlite3_mprintf(
-              "crsql_changes.site_id only supports the IS, IS NOT, =, != "
-              "operators");
-          return SQLITE_CONSTRAINT;
-        }
-        requestorIdx = i;
-        pIdxInfo->aConstraintUsage[i].argvIndex = 2;
-        pIdxInfo->aConstraintUsage[i].omit = 1;
         idxNum |= 4;
-
-        if (pConstraint->op == SQLITE_INDEX_CONSTRAINT_EQ ||
-            pConstraint->op == SQLITE_INDEX_CONSTRAINT_IS ||
-            pConstraint->op == SQLITE_INDEX_CONSTRAINT_ISNULL) {
-          idxNum |= 8;
-        }
         break;
     }
   }
@@ -476,27 +497,16 @@ static int changesBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
   if ((idxNum & 6) == 6) {
     pIdxInfo->estimatedCost = (double)1;
     pIdxInfo->estimatedRows = 1;
-
-    pIdxInfo->aConstraintUsage[versionIdx].argvIndex = 1;
-    pIdxInfo->aConstraintUsage[versionIdx].omit = 1;
-    pIdxInfo->aConstraintUsage[requestorIdx].argvIndex = 2;
-    pIdxInfo->aConstraintUsage[requestorIdx].omit = 1;
   }
   // only the version constraint is present
   else if ((idxNum & 2) == 2) {
     pIdxInfo->estimatedCost = (double)10;
     pIdxInfo->estimatedRows = 10;
-
-    pIdxInfo->aConstraintUsage[versionIdx].argvIndex = 1;
-    pIdxInfo->aConstraintUsage[versionIdx].omit = 1;
   }
   // only the requestor constraint is present
   else if ((idxNum & 4) == 4) {
     pIdxInfo->estimatedCost = (double)2147483647;
     pIdxInfo->estimatedRows = 2147483647;
-
-    pIdxInfo->aConstraintUsage[requestorIdx].argvIndex = 1;
-    pIdxInfo->aConstraintUsage[requestorIdx].omit = 1;
   }
   // no constraints are present
   else {
@@ -505,7 +515,45 @@ static int changesBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
   }
 
   pIdxInfo->idxNum = idxNum;
+  pIdxInfo->idxStr = sqlite3_str_finish(pStr);
+  pIdxInfo->needToFreeIdxStr = 1;
   return SQLITE_OK;
+}
+
+static const char *getOperatorString(unsigned char op) {
+  // SQLITE_INDEX_CONSTRAINT_NE
+  switch (op) {
+    case SQLITE_INDEX_CONSTRAINT_EQ:
+      return "=";
+    case SQLITE_INDEX_CONSTRAINT_GT:
+      return ">";
+    case SQLITE_INDEX_CONSTRAINT_LE:
+      return "<=";
+    case SQLITE_INDEX_CONSTRAINT_LT:
+      return "<";
+    case SQLITE_INDEX_CONSTRAINT_GE:
+      return ">=";
+    case SQLITE_INDEX_CONSTRAINT_MATCH:
+      return "MATCH";
+    case SQLITE_INDEX_CONSTRAINT_LIKE:
+      return "LIKE";
+    case SQLITE_INDEX_CONSTRAINT_GLOB:
+      return "GLOB";
+    case SQLITE_INDEX_CONSTRAINT_REGEXP:
+      return "REGEXP";
+    case SQLITE_INDEX_CONSTRAINT_NE:
+      return "!=";
+    case SQLITE_INDEX_CONSTRAINT_ISNOT:
+      return "IS NOT";
+    case SQLITE_INDEX_CONSTRAINT_ISNOTNULL:
+      return "IS NOT NULL";
+    case SQLITE_INDEX_CONSTRAINT_ISNULL:
+      return "IS NULL";
+    case SQLITE_INDEX_CONSTRAINT_IS:
+      return "IS";
+    default:
+      return 0;
+  }
 }
 
 static int changesApply(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,

--- a/core/src/changes-vtab.h
+++ b/core/src/changes-vtab.h
@@ -4,7 +4,7 @@
  *
  * To fetch a changeset:
  * ```sql
- * SELECT * FROM crsql_chages WHERE site_id != SITE_ID AND version > V
+ * SELECT * FROM crsql_chages WHERE site_id IS NOT SITE_ID AND version > V
  * ```
  *
  * The site id parameter is used to prevent a site from fetching its own

--- a/core/src/changes-vtab.test.c
+++ b/core/src/changes-vtab.test.c
@@ -25,7 +25,7 @@ static void testManyPkTable() {
   rc += sqlite3_exec(db, "INSERT INTO foo VALUES (4,5,6);", 0, 0, 0);
   assert(rc == SQLITE_OK);
 
-  rc += sqlite3_prepare_v2(db, "SELECT * FROM crsql_changes()", -1, &pStmt, 0);
+  rc += sqlite3_prepare_v2(db, "SELECT * FROM crsql_changes", -1, &pStmt, 0);
   assert(rc == SQLITE_OK);
 
   while (sqlite3_step(pStmt) == SQLITE_ROW) {
@@ -37,6 +37,77 @@ static void testManyPkTable() {
   crsql_close(db);
   printf("\t\e[0;32mSuccess\e[0m\n");
 }
+
+static void assertCount(sqlite3 *db, const char *sql, int expected) {
+  sqlite3_stmt *pStmt;
+  int rc = sqlite3_prepare_v2(db, sql, -1, &pStmt, 0);
+  assert(rc == SQLITE_OK);
+  assert(sqlite3_step(pStmt) == SQLITE_ROW);
+  printf("expected: %d, actual: %d\n", expected, sqlite3_column_int(pStmt, 0));
+  assert(sqlite3_column_int(pStmt, 0) == expected);
+  sqlite3_finalize(pStmt);
+}
+
+static void testFilters() {
+  printf("Filters\n");
+
+  sqlite3 *db;
+  int rc;
+  rc = sqlite3_open(":memory:", &db);
+
+  rc = sqlite3_exec(db, "CREATE TABLE foo (a primary key, b);", 0, 0, 0);
+  rc += sqlite3_exec(db, "SELECT crsql_as_crr('foo');", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+  rc += sqlite3_exec(db, "INSERT INTO foo VALUES (1,2);", 0, 0, 0);
+  rc += sqlite3_exec(db, "INSERT INTO foo VALUES (2,3);", 0, 0, 0);
+  rc += sqlite3_exec(db, "INSERT INTO foo VALUES (3,4);", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  printf("no filters\n");
+  assertCount(db, "SELECT count(*) FROM crsql_changes", 3);
+
+  // now test:
+  // 1. site_id comparison
+  // 2. db_version comparison
+
+  printf("is null\n");
+  assertCount(db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NULL",
+              3);
+
+  printf("is not null\n");
+  assertCount(
+      db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT NULL", 0);
+
+  printf("equals\n");
+  assertCount(
+      db, "SELECT count(*) FROM crsql_changes WHERE site_id = crsql_siteid()",
+      0);
+
+  // 0 rows is actually correct ANSI sql behavior. NULLs are never equal, or not
+  // equal, to anything in ANSI SQL. So users must use `IS NOT` to check rather
+  // than !=.
+  // https://stackoverflow.com/questions/60017275/why-null-is-not-equal-to-anything-is-a-false-statement
+  printf("not equals\n");
+  assertCount(
+      db, "SELECT count(*) FROM crsql_changes WHERE site_id != crsql_siteid()",
+      0);
+
+  printf("is not\n");
+  // All rows are currently null for site_id
+  assertCount(
+      db,
+      "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT crsql_siteid()",
+      3);
+
+  // compare on db_version _and_ site_id
+
+  // compare on pks, table name, other not perfectly supported columns
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+// test value extraction under all filter conditions
 
 // static void testSinglePksTable()
 // {
@@ -57,4 +128,5 @@ static void testManyPkTable() {
 void crsqlChangesVtabTestSuite() {
   printf("\e[47m\e[1;30mSuite: crsql_changesVtab\e[0m\n");
   testManyPkTable();
+  testFilters();
 }

--- a/core/src/changes-vtab.test.c
+++ b/core/src/changes-vtab.test.c
@@ -109,6 +109,12 @@ static void testFilters() {
               "db_version < 2",
               1);
 
+  printf("OR condition\n");
+  assertCount(db,
+              "SELECT count(*) FROM crsql_changes WHERE db_version > 2 OR "
+              "site_id IS NULL",
+              3);
+
   // compare on pks, table name, other not perfectly supported columns
 
   crsql_close(db);

--- a/core/src/changes-vtab.test.c
+++ b/core/src/changes-vtab.test.c
@@ -86,6 +86,7 @@ static void testFilters() {
   // 0 rows is actually correct ANSI sql behavior. NULLs are never equal, or not
   // equal, to anything in ANSI SQL. So users must use `IS NOT` to check rather
   // than !=.
+  //
   // https://stackoverflow.com/questions/60017275/why-null-is-not-equal-to-anything-is-a-false-statement
   printf("not equals\n");
   assertCount(
@@ -100,6 +101,13 @@ static void testFilters() {
       3);
 
   // compare on db_version _and_ site_id
+
+  // compare upper and lower bound on db_version
+  printf("double bounded version\n");
+  assertCount(db,
+              "SELECT count(*) FROM crsql_changes WHERE db_version >= 1 AND "
+              "db_version < 2",
+              1);
 
   // compare on pks, table name, other not perfectly supported columns
 

--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -269,11 +269,11 @@ static void teste2e() {
   // printf("db2sid: %s\n", db2siteid);
   // printf("db3sid: %s\n", db3siteid);
   // printf("tempsid: %s\n", tmpSiteid);
-  assert(strcmp(tmpSiteid, db1siteid) == 0);
+  assert(strcmp(tmpSiteid, "NULL") == 0);
 
   rc = sqlite3_step(pStmt3);
   assert(rc == SQLITE_ROW);
-  assert(strcmp((const char *)sqlite3_column_text(pStmt3, 0), db2siteid) == 0);
+  assert(strcmp((const char *)sqlite3_column_text(pStmt3, 0), "NULL") == 0);
   sqlite3_finalize(pStmt3);
 
   rc = sqlite3_prepare_v2(db2, "SELECT * FROM foo ORDER BY a ASC", -1, &pStmt2,
@@ -586,7 +586,7 @@ static void testPullingOnlyLocalChanges() {
   // `IS NOT NULL` also fails to call the virtual table bestIndex function with
   // any constraints p pIdxInfo->nConstraint
   sqlite3_prepare_v2(db,
-                     "SELECT count(*) FROM crsql_changes WHERE site_id = NULL",
+                     "SELECT count(*) FROM crsql_changes WHERE site_id IS NULL",
                      -1, &pStmt, 0);
 
   rc = sqlite3_step(pStmt);
@@ -594,12 +594,13 @@ static void testPullingOnlyLocalChanges() {
 
   int count = sqlite3_column_int(pStmt, 0);
   // we created 2 local changes, we should get 2 changes back
+  printf("count: %d\n", count);
   assert(count == 2);
   sqlite3_finalize(pStmt);
 
-  sqlite3_prepare_v2(db,
-                     "SELECT count(*) FROM crsql_changes WHERE site_id != NULL",
-                     -1, &pStmt, 0);
+  sqlite3_prepare_v2(
+      db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT NULL", -1,
+      &pStmt, 0);
   rc = sqlite3_step(pStmt);
   assert(rc == SQLITE_ROW);
   count = sqlite3_column_int(pStmt, 0);

--- a/js/packages/node-tests/src/__tests__/xplat.test.ts
+++ b/js/packages/node-tests/src/__tests__/xplat.test.ts
@@ -1,3 +1,5 @@
+(global as any).navigator = {};
+
 import { test, expect } from "vitest";
 import { DBAsync, DB as DBSync } from "@vlcn.io/xplat-api";
 type DB = DBAsync | DBSync;
@@ -20,7 +22,6 @@ function runTests(tests: {
   });
 }
 
-(global as any).navigator = {};
 // import { wdbTests } from "@vlcn.io/xplat-tests";
 // runTests(wdbTests);
 

--- a/js/packages/node-tests/src/__tests__/xplat.test.ts
+++ b/js/packages/node-tests/src/__tests__/xplat.test.ts
@@ -1,4 +1,4 @@
-(global as any).navigator = {};
+import "../fill.js";
 
 import { test, expect } from "vitest";
 import { DBAsync, DB as DBSync } from "@vlcn.io/xplat-api";

--- a/js/packages/node-tests/src/fill.ts
+++ b/js/packages/node-tests/src/fill.ts
@@ -1,0 +1,1 @@
+(global as any).navigator = {};

--- a/js/packages/p2p/src/WholeDbReplicator.ts
+++ b/js/packages/p2p/src/WholeDbReplicator.ts
@@ -280,7 +280,6 @@ export class WholeDbReplicator {
 
   private changesRequested = async (from: SiteIDWire, since: bigint) => {
     const fromAsBlob = uuidParse(from);
-    // The casting is due to bigint support problems in various wasm builds of sqlite
     const changes: Changeset[] = await this.db.execA<Changeset>(
       `SELECT "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_siteid()) FROM crsql_changes WHERE site_id IS NOT ? AND db_version > ?`,
       [fromAsBlob, since]

--- a/js/packages/p2p/src/WholeDbReplicator.ts
+++ b/js/packages/p2p/src/WholeDbReplicator.ts
@@ -282,7 +282,7 @@ export class WholeDbReplicator {
     const fromAsBlob = uuidParse(from);
     // The casting is due to bigint support problems in various wasm builds of sqlite
     const changes: Changeset[] = await this.db.execA<Changeset>(
-      `SELECT "table", "pk", "cid", "val", "col_version", "db_version", "site_id" FROM crsql_changes WHERE site_id != ? AND db_version > ?`,
+      `SELECT "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_siteid()) FROM crsql_changes WHERE site_id IS NOT ? AND db_version > ?`,
       [fromAsBlob, since]
     );
 

--- a/js/packages/server-core/src/db.ts
+++ b/js/packages/server-core/src/db.ts
@@ -46,7 +46,7 @@ class DB {
       this.#applySchema(create.schemaName);
     }
     this.#pullChangesetStmt = this.#db.prepare(
-      `SELECT "table", "pk", "cid", "val", "col_version", "db_version" FROM crsql_changes WHERE db_version > ? AND site_id != ?`
+      `SELECT "table", "pk", "cid", "val", "col_version", "db_version" FROM crsql_changes WHERE db_version > ? AND site_id IS NOT ?`
     );
     this.#pullChangesetStmt.raw(true);
 

--- a/js/packages/xplat-tests/src/index.ts
+++ b/js/packages/xplat-tests/src/index.ts
@@ -1,3 +1,3 @@
 export { tests as wdbTests } from "./WholeDbRepliator.test.js";
 export { tests as tblrxTests } from "./tblrx.test.js";
-export {tests as intTests} from './int.test.js';
+export { tests as intTests } from "./int.test.js";

--- a/py/correctness/tests/test_sync.py
+++ b/py/correctness/tests/test_sync.py
@@ -1,7 +1,7 @@
 from crsql_correctness import connect, close, min_db_v
 import pprint
 
-# js_tests included a Fast-Check driven merge test which is much more complete than what we have here
+# js_tests includes a Fast-Check driven merge test which is much more complete than what we have here
 
 
 def init():


### PR DESCRIPTION
Note that `pk` and `tbl_name` filters against `crsql_changes` are not yet performant and require table scans.

db_version is indexed and performant. tbl_name and pk are indexed as well and could be made performant with some tweaks to how the virtual table passes information to the base tables.