### PR TITLE
implement crsql_rows_impacted 

### DIFF
--- a/core/src/changes-vtab-write.c
+++ b/core/src/changes-vtab-write.c
@@ -416,6 +416,8 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
   // the table.
   // Is it fine if we prevent anyone from using `rowid` on a vtab?
   // or must we convert to `without rowid`?
+  // TODO: add invocation of rowid slab algorithm here.
   *pRowid = insertDbVrsn;
+  pTab->pExtData->rowsImpacted += 1;
   return rc;
 }

--- a/core/src/crsqlite.c
+++ b/core/src/crsqlite.c
@@ -475,6 +475,12 @@ static void crsqlFinalize(sqlite3_context *context, int argc,
   crsql_finalize(pExtData);
 }
 
+static void crsqlRowsImpacted(sqlite3_context *context, int argc,
+                              sqlite3_value **argv) {
+  crsql_ExtData *pExtData = (crsql_ExtData *)sqlite3_user_data(context);
+  sqlite3_result_int(context, pExtData->rowsImpacted);
+}
+
 static int commitHook(void *pUserData) {
   crsql_ExtData *pExtData = (crsql_ExtData *)pUserData;
 
@@ -562,6 +568,12 @@ __declspec(dllexport)
     rc = sqlite3_create_function(db, "crsql_finalize", -1,
                                  SQLITE_UTF8 | SQLITE_DIRECTONLY, pExtData,
                                  crsqlFinalize, 0, 0);
+  }
+
+  if (rc == SQLITE_OK) {
+    rc = sqlite3_create_function(db, "crsql_rows_impacted", 0,
+                                 SQLITE_UTF8 | SQLITE_INNOCUOUS, pExtData,
+                                 crsqlRowsImpacted, 0, 0);
   }
 
   if (rc == SQLITE_OK) {

--- a/core/src/ext-data.c
+++ b/core/src/ext-data.c
@@ -39,6 +39,7 @@ crsql_ExtData *crsql_newExtData(sqlite3 *db) {
   pExtData->pDbVersionStmt = 0;
   pExtData->zpTableInfos = 0;
   pExtData->tableInfosLen = 0;
+  pExtData->rowsImpacted = 0;
 
   rc = crsql_fetchPragmaDataVersion(db, pExtData);
   if (rc == -1) {

--- a/core/src/ext-data.h
+++ b/core/src/ext-data.h
@@ -27,6 +27,10 @@ struct crsql_ExtData {
   sqlite3_stmt *pDbVersionStmt;
   crsql_TableInfo **zpTableInfos;
   int tableInfosLen;
+
+  // tracks the number of rows impacted by all inserts into crsql_changes in the
+  // current transaction. This number is reset on transaction commit.
+  int rowsImpacted;
 };
 
 crsql_ExtData *crsql_newExtData(sqlite3 *db);

--- a/core/src/rows-impacted.test.c
+++ b/core/src/rows-impacted.test.c
@@ -1,0 +1,336 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "crsqlite.h"
+
+int crsql_close(sqlite3 *db);
+
+static sqlite3 *createDb() {
+  int rc = SQLITE_OK;
+  sqlite3 *db;
+  rc = sqlite3_open(":memory:", &db);
+  rc += sqlite3_exec(db, "CREATE TABLE foo (a primary key, b)", 0, 0, 0);
+  rc += sqlite3_exec(db, "SELECT crsql_as_crr('foo')", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+  return db;
+}
+
+static void testSingleInsertSingleTx() {
+  printf("SingleInsertSingleTx\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 1);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  // rows impacted gets reset
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  int impacted = sqlite3_column_int(pStmt, 0);
+  assert(impacted == 0);
+  sqlite3_finalize(pStmt);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+static void testManyInsertsInATx() {
+  printf("ManyInsertsInATx\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 2, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 3, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 3);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  // rows impacted gets reset
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 0);
+  sqlite3_finalize(pStmt);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+static void testMultipartInsertInTx() {
+  printf("MultipartInsertInTx\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db,
+      "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 1, 1, NULL), "
+      "('foo', 2, 'b', 2, 1, 1, NULL), ('foo', 3, 'b', 2, 1, 1, NULL)",
+      0, 0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 3);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  // rows impacted gets reset
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 0);
+  sqlite3_finalize(pStmt);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+// count should reset between transactions
+static void testManyTxns() {
+  printf("ManyTxns\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 1);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 2, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 3, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  int impacted = sqlite3_column_int(pStmt, 0);
+  assert(impacted == 2);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+// You can't do this. `crsql_rows_impacted` is evaulated before the insert is
+// run thus the right value can never be returned by `RETURNING` in this setup.
+// static void testReturningInTx() {
+//   printf("RetruningInTx\n");
+//   int rc = SQLITE_OK;
+//   char *err = 0;
+//   sqlite3 *db = createDb();
+//   sqlite3_stmt *pStmt = 0;
+
+//   rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+//   rc += sqlite3_prepare_v2(
+//       db,
+//       "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 1, 1, NULL), "
+//       "('foo', 2, 'b', 2, 1, 1, NULL), ('foo', 3, 'b', 2, 1, 1, NULL) "
+//       "RETURNING crsql_rows_impacted()",
+//       -1, &pStmt, 0);
+//   rc += sqlite3_step(pStmt);
+//   int impacted = sqlite3_column_int(pStmt, 0);
+//   printf("impacted: %d\n", impacted);
+//   assert(impacted == 3);
+//   sqlite3_finalize(pStmt);
+//   rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+//   assert(rc == SQLITE_OK);
+
+//   crsql_close(db);
+//   printf("\t\e[0;32mSuccess\e[0m\n");
+// }
+
+static void testUpdateThatDoesNotChangeAnything() {
+  printf("UpdateThatDoesNotChangeAnything\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "INSERT INTO foo VALUES (1, 2)", 0, 0, 0);
+
+  rc += sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 0);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  // now test value <
+  rc += sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 0, 1, 1, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 0);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  // now test clock <
+  rc += sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 0, 0, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 0);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+static void testDeleteThatDoesNotChangeAnything() {
+  printf("DeleteThatDoesNotChangeAnything\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "INSERT INTO foo VALUES (1, 2)", 0, 0, 0);
+  rc = sqlite3_exec(db, "DELETE FROM foo", 0, 0, 0);
+
+  rc += sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(db,
+                     "INSERT INTO crsql_changes VALUES ('foo', 1, "
+                     "'__crsql_del', NULL, 1, 2, NULL)",
+                     0, 0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 0);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+static void testCreateThatDoesNotChangeAnything() {
+  printf("UpdateThatDoesNotChangeAnything\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "INSERT INTO foo VALUES (1, 2)", 0, 0, 0);
+
+  rc += sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 1, 1, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 0);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+static void testValueWin() {
+  printf("ValueWin\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "INSERT INTO foo VALUES (1, 2)", 0, 0, 0);
+
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 3, 1, 1, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 1);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+static void testClockWin() {
+  printf("ClockWin\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "INSERT INTO foo VALUES (1, 2)", 0, 0, 0);
+
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(
+      db, "INSERT INTO crsql_changes VALUES ('foo', 1, 'b', 2, 2, 2, NULL)", 0,
+      0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 1);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+void rowsImpactedTestSuite() {
+  printf("\e[47m\e[1;30mSuite: rows_impacted\e[0m\n");
+
+  testSingleInsertSingleTx();
+  testManyInsertsInATx();
+  testMultipartInsertInTx();
+  testManyTxns();
+  testUpdateThatDoesNotChangeAnything();
+  testDeleteThatDoesNotChangeAnything();
+  testValueWin();
+  testClockWin();
+}

--- a/core/src/tests.c
+++ b/core/src/tests.c
@@ -24,6 +24,7 @@ void crsqlChangesVtabCommonTestSuite();
 void crsqlExtDataTestSuite();
 void crsqlFractSuite();
 void crsqlIsCrrTestSuite();
+void rowsImpactedTestSuite();
 
 int main(int argc, char *argv[]) {
   char *suite = "all";
@@ -44,6 +45,7 @@ int main(int argc, char *argv[]) {
   SUITE("crsql") crsqlTestSuite();
   SUITE("fract") crsqlFractSuite();
   SUITE("is_crr") crsqlIsCrrTestSuite();
+  SUITE("rows_impacted") rowsImpactedTestSuite();
 
   sqlite3_shutdown();
 }

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,17 @@
+Compact on deletes. You have clock entries in there that need not exist after a row is deleted!!!
+
+---
+
+accumulating impacted rows:
+
+- if many inserts to crsql_changes within the same tx... is xBegin called for each or only once for the
+  entire tx?
+- If the latter, we will return the _total_ accumulation across the entire TX.
+
+---
+
+---
+
 rlwrap
 
 PK only table.

--- a/py/perf/notes.md
+++ b/py/perf/notes.md
@@ -1,0 +1,1 @@
+jupyter-lab from this dir


### PR DESCRIPTION
This allows users to know whether or not an insert into `crsql_changes` actually made any modifications.

# Usage:

```sql
BEGIN;
INSERT INTO crsql_changes VALUES ...;
SELECT crsql_rows_impacted();
COMMIT;
```

# Description:
`crsql_rows_impacted` will return the total number of rows modified by all inserts into `crsql_changes` in the current transaction. On transaction commit, the value is reset to 0.

- Each connection has its own copy of this counter so concurrent transactions are isolated since connections can't be shared between threads (a SQLite constraint).
- This count is accumulated at the _top level transaction_. In other words, you cannot get independent counts for nested transactions / savepoints.
