### PR TITLE
Many more schema migration tests + bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ The full documentation site is available [here](https://vlcn.io/docs/getting-sta
   - `SELECT "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_siteid()) FROM crsql_changes WHERE db_version > x AND site_id IS NULL` -- to get local changes
   - `SELECT "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_siteid()) FROM crsql_changes WHERE db_version > x AND site_id IS NOT some_site` -- to get all changes excluding those synced from some site
   - `INSERT INTO crsql_changes VALUES ([patches receied from select on another peer])`
-- And `crsql_alter_begin('table_name')` & `crsql_alter_commit('table_name')` primitives to allow altering table definitions that have been upgraded to `crr`s.
+- And `crsql_begin_alter('table_name')` & `crsql_alter_commit('table_name')` primitives to allow altering table definitions that have been upgraded to `crr`s.
   - Until we move forward with extending the syntax of SQLite to be CRR aware, altering CRRs looks like:
     ```sql
-    SELECT crsql_alter_begin('table_name');
+    SELECT crsql_begin_alter('table_name');
     -- 1 or more alterations to `table_name`
     ALTER TABLE table_name ...;
-    SELECT crsql_alter_commit('table_name');
+    SELECT crsql_commit_alter('table_name');
     ```
     A future version of cr-sqlite may extend the SQL syntax to make this more natural.
 

--- a/core/README.md
+++ b/core/README.md
@@ -51,13 +51,13 @@ The full documentation site is available [here](https://vlcn.io/docs/getting-sta
   - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id IS NULL` -- to get local changes
   - `SELECT * FROM crsql_changes WHERE db_version > x AND site_id IS NOT some_site` -- to get all changes excluding those synced from some site
   - `INSERT INTO crsql_changes VALUES ([patches receied from select on another peer])`
-- And `crsql_alter_begin('table_name')` & `crsql_alter_commit('table_name')` primitives to allow altering table definitions that have been upgraded to `crr`s.
+- And `crsql_begin_alter('table_name')` & `crsql_alter_commit('table_name')` primitives to allow altering table definitions that have been upgraded to `crr`s.
   - Until we move forward with extending the syntax of SQLite to be CRR aware, altering CRRs looks like:
     ```sql
-    SELECT crsql_alter_begin('table_name');
+    SELECT crsql_begin_alter('table_name');
     -- 1 or more alterations to `table_name`
     ALTER TABLE table_name ...;
-    SELECT crsql_alter_commit('table_name');
+    SELECT crsql_commit_alter('table_name');
     ```
     A future version of cr-sqlite may extend the SQL syntax to make this more natural.
 

--- a/core/rs/core/src/automigrate.rs
+++ b/core/rs/core/src/automigrate.rs
@@ -386,7 +386,7 @@ fn maybe_recreate_index(
         // drop to finalize those statements
         drop(fetch_is_unique_mem);
         drop(fetch_is_unique_local);
-        return recreate_index(local_db, table, idx, mem_db);
+        return recreate_index(local_db, idx);
     }
 
     let fetch_idx_cols_mem = mem_db.prepare_v2(IDX_COLS_SQL)?;
@@ -400,25 +400,20 @@ fn maybe_recreate_index(
             // drop to finalize those statements
             drop(fetch_idx_cols_local);
             drop(fetch_idx_cols_mem);
-            return recreate_index(local_db, table, idx, mem_db);
+            return recreate_index(local_db, idx);
         }
         fetch_idx_cols_mem.step()?;
         fetch_idx_cols_local.step()?;
     }
 
     if mem_result != local_result {
-        return recreate_index(local_db, table, idx, mem_db);
+        return recreate_index(local_db, idx);
     }
 
     Ok(ResultCode::OK)
 }
 
-fn recreate_index(
-    local_db: *mut sqlite3,
-    table: &str,
-    idx: &str,
-    mem_db: &ManagedConnection,
-) -> Result<ResultCode, ResultCode> {
+fn recreate_index(local_db: *mut sqlite3, idx: &str) -> Result<ResultCode, ResultCode> {
     let indices = vec![idx.to_string()];
     drop_indices(local_db, &indices)?;
     // no need to call add_indices

--- a/core/rs/core/src/backfill.rs
+++ b/core/rs/core/src/backfill.rs
@@ -131,8 +131,10 @@ fn fill_column(
     non_pk_col: &str,
 ) -> Result<ResultCode, ResultCode> {
     // Only return rows for which
-    // - a row does not exist for that pk combo _and_ cid in the clock table
-    // an optimization would be to filter out rows which are set to the default value.
+    // - a row does not exist for that pk combo _and_ cid in the clock table.
+    // An optimization would be to filter out rows which are set to the default value.
+    // We can get the default value from the pragma and add a WHERE clause against
+    // t1.{col_name} where t1.{col_name} != {default_value}
     let sql = format!(
         "SELECT {pk_cols} FROM {table} as t1
           LEFT JOIN \"{table}__crsql_clock\" as t2 ON {pk_on_conditions} AND t2.__crsql_col_name = ?

--- a/core/rs/core/src/backfill.rs
+++ b/core/rs/core/src/backfill.rs
@@ -91,6 +91,11 @@ fn create_clock_rows_from_stmt(
             write_stmt.step()?;
             write_stmt.reset()?;
         }
+        if (non_pk_cols.len() == 0) {
+            write_stmt.bind_text(pk_cols.len() as i32 + 1, "__crsql_pko", Destructor::STATIC)?;
+            write_stmt.step()?;
+            write_stmt.reset()?;
+        }
     }
 
     Ok(ResultCode::OK)

--- a/core/rs/core/src/backfill.rs
+++ b/core/rs/core/src/backfill.rs
@@ -99,7 +99,7 @@ fn create_clock_rows_from_stmt(
 * If not, fill the data in for it for each row.
 *
 * Can we optimize and skip cases where it is equivalent to the default value?
-* E.g., adding a new column should not require a backfill...
+* E.g., adding a new column set to default values should not require a backfill...
 */
 fn backfill_missing_columns(
     db: *mut sqlite3,
@@ -145,6 +145,8 @@ fn fill_column(
     // We don't technically need this join, right?
     // There should never be a partially filled column.
     // If there is there's likely a bug elsewhere.
+    // Actually partially filled columns can happen during the 12 step migration
+    // process if someone adds rows to the table while the migration is running.
     let sql = format!(
         "SELECT {pk_cols} FROM {table} as t1",
         table = crate::escape_ident(table),

--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -4,6 +4,7 @@ mod automigrate;
 mod backfill;
 mod is_crr;
 mod teardown;
+mod util;
 
 use core::{ffi::c_char, slice};
 extern crate alloc;

--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -100,6 +100,7 @@ pub extern "C" fn crsql_backfill_table(
     pk_cols_len: c_int,
     non_pk_cols: *const *const c_char,
     non_pk_cols_len: c_int,
+    is_commit_alter: c_int,
 ) -> c_int {
     let table = unsafe { CStr::from_ptr(table).to_str() };
     let pk_cols = unsafe {
@@ -120,7 +121,7 @@ pub extern "C" fn crsql_backfill_table(
     let result = match (table, pk_cols, non_pk_cols) {
         (Ok(table), Ok(pk_cols), Ok(non_pk_cols)) => {
             let db = context.db_handle();
-            backfill_table(db, table, pk_cols, non_pk_cols)
+            backfill_table(db, table, pk_cols, non_pk_cols, is_commit_alter != 0)
         }
         _ => Err(ResultCode::ERROR),
     };

--- a/core/rs/core/src/util.rs
+++ b/core/rs/core/src/util.rs
@@ -1,0 +1,38 @@
+extern crate alloc;
+
+use alloc::string::String;
+use sqlite::{sqlite3, ColumnType, Connection, ResultCode};
+use sqlite_nostd as sqlite;
+
+pub fn get_dflt_value(
+    db: *mut sqlite3,
+    table: &str,
+    col: &str,
+) -> Result<Option<String>, ResultCode> {
+    let sql = "SELECT [dflt_value], [notnull] FROM pragma_table_info(?) WHERE name = ?";
+    let stmt = db.prepare_v2(sql)?;
+    stmt.bind_text(1, table, sqlite_nostd::Destructor::STATIC)?;
+    stmt.bind_text(2, col, sqlite_nostd::Destructor::STATIC)?;
+    let rc = stmt.step()?;
+    if rc == ResultCode::DONE {
+        // There should always be a row for a column in pragma_table_info
+        return Err(ResultCode::DONE);
+    }
+
+    let notnull = stmt.column_int(1)?;
+    let dflt_column_type = stmt.column_type(0)?;
+
+    // if the column is nullable and no default value is specified
+    // then the default value is null.
+    if notnull == 0 && dflt_column_type == ColumnType::Null {
+        return Ok(Some(String::from("NULL")));
+    }
+
+    if dflt_column_type == ColumnType::Null {
+        // no default value specified
+        // and the column is not nullable
+        return Ok(None);
+    }
+
+    return Ok(Some(String::from(stmt.column_text(0)?)));
+}

--- a/core/src/crsqlite.c
+++ b/core/src/crsqlite.c
@@ -483,7 +483,8 @@ int crsql_compactPostAlter(sqlite3 *db, const char *tblName,
     }
     sqlite3_str_appendf(
         pDynStr,
-        "DELETE FROM \"%w__crsql_clock\" WHERE NOT EXISTS (SELECT 1 FROM "
+        "DELETE FROM \"%w__crsql_clock\" WHERE __crsql_col_name != "
+        "'__crsql_del' AND NOT EXISTS (SELECT 1 FROM "
         "\"%w\" WHERE ",
         tblName);
     // get table info

--- a/core/src/crsqlite.c
+++ b/core/src/crsqlite.c
@@ -254,7 +254,8 @@ int crsql_createClockTable(sqlite3 *db, crsql_TableInfo *tableInfo,
  * all triggers, views, tables
  */
 static int createCrr(sqlite3_context *context, sqlite3 *db,
-                     const char *schemaName, const char *tblName, char **err) {
+                     const char *schemaName, const char *tblName,
+                     int isCommitAlter, char **err) {
   int rc = SQLITE_OK;
   crsql_TableInfo *tableInfo = 0;
 
@@ -295,7 +296,7 @@ static int createCrr(sqlite3_context *context, sqlite3 *db,
     nonPkNames[i] = tableInfo->nonPks[i].name;
   }
   rc = crsql_backfill_table(context, tblName, pkNames, tableInfo->pksLen,
-                            nonPkNames, tableInfo->nonPksLen);
+                            nonPkNames, tableInfo->nonPksLen, isCommitAlter);
   sqlite3_free(pkNames);
   sqlite3_free(nonPkNames);
 
@@ -355,7 +356,7 @@ static void crsqlMakeCrrFunc(sqlite3_context *context, int argc,
     return;
   }
 
-  rc = createCrr(context, db, schemaName, tblName, &errmsg);
+  rc = createCrr(context, db, schemaName, tblName, 0, &errmsg);
   if (rc != SQLITE_OK) {
     sqlite3_result_error(context, errmsg, -1);
     sqlite3_result_error_code(context, rc);
@@ -562,7 +563,7 @@ static void crsqlCommitAlterFunc(sqlite3_context *context, int argc,
   crsql_ExtData *pExtData = (crsql_ExtData *)sqlite3_user_data(context);
   rc = crsql_compactPostAlter(db, tblName, pExtData, &errmsg);
   if (rc == SQLITE_OK) {
-    rc = createCrr(context, db, schemaName, tblName, &errmsg);
+    rc = createCrr(context, db, schemaName, tblName, 1, &errmsg);
   }
   if (rc == SQLITE_OK) {
     rc = sqlite3_exec(db, "RELEASE alter_crr", 0, 0, &errmsg);

--- a/core/src/crsqlite.c
+++ b/core/src/crsqlite.c
@@ -123,7 +123,7 @@ static int createSchemaTableIfNotExists(sqlite3 *db) {
 
   char *zSql = sqlite3_mprintf(
       "CREATE TABLE IF NOT EXISTS \"%s\" (\"key\" TEXT PRIMARY KEY, \"value\" "
-      "TEXT);",
+      "ANY);",
       TBL_SCHEMA);
   rc = sqlite3_exec(db, zSql, 0, 0, 0);
   sqlite3_free(zSql);

--- a/core/src/crsqlite.c
+++ b/core/src/crsqlite.c
@@ -486,7 +486,7 @@ int crsql_compactPostAlter(sqlite3 *db, const char *tblName,
         "DELETE FROM \"%w__crsql_clock\" WHERE __crsql_col_name != "
         "'__crsql_del' AND NOT EXISTS (SELECT 1 FROM "
         "\"%w\" WHERE ",
-        tblName);
+        tblName, tblName);
     // get table info
     rc = crsql_ensureTableInfosAreUpToDate(db, pExtData, errmsg);
     if (rc != SQLITE_OK) {

--- a/core/src/crsqlite.h
+++ b/core/src/crsqlite.h
@@ -17,7 +17,8 @@ SQLITE_EXTENSION_INIT3
 int crsql_createClockTable(sqlite3 *db, crsql_TableInfo *tableInfo, char **err);
 int crsql_backfill_table(sqlite3_context *context, const char *tblName,
                          const char **zpkNames, int pkCount,
-                         const char **zNonPkNames, int nonPkCount);
+                         const char **zNonPkNames, int nonPkCount,
+                         int isCommitAlter);
 int crsql_is_crr(sqlite3 *db, const char *tblName);
 
 #endif

--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -354,7 +354,7 @@ static void testSelectChangesAfterChangingColumnName() {
   // insert some rows post schema change
   rc = sqlite3_exec(db, "INSERT INTO foo VALUES (2, 3);", 0, 0, 0);
   rc += sqlite3_prepare_v2(
-      db, "SELECT * FROM crsql_changes WHERE db_version > 1", -1, &pStmt, 0);
+      db, "SELECT * FROM crsql_changes WHERE db_version >= 1", -1, &pStmt, 0);
   assert(rc == SQLITE_OK);
   numRows = 0;
   // Columns that no long exist post-alter should not

--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -359,7 +359,12 @@ static void testSelectChangesAfterChangingColumnName() {
   numRows = 0;
   // Columns that no long exist post-alter should not
   // be retained for replication
+  int first = 1;
   while ((rc = sqlite3_step(pStmt)) == SQLITE_ROW) {
+    if (first == 1) {
+      first = 0;
+      continue;
+    }
     assert(strcmp("foo", (const char *)sqlite3_column_text(
                              pStmt, CHANGES_SINCE_VTAB_TBL)) == 0);
     assert(strcmp("2", (const char *)sqlite3_column_text(

--- a/core/src/ext-data.c
+++ b/core/src/ext-data.c
@@ -222,7 +222,7 @@ int crsql_fetchDbVersionFromStorage(sqlite3 *db, crsql_ExtData *pExtData,
 }
 
 /**
- * This will return the db version if it exists in `pExtData`
+ * This fills the dbVersion into `pExtData` if it is not already cached there
  *
  * If it does not exist there, it will fetch the current db version
  * from the database.

--- a/core/src/tableinfo.h
+++ b/core/src/tableinfo.h
@@ -37,6 +37,7 @@ crsql_ColumnInfo *crsql_extractBaseCols(crsql_ColumnInfo *colInfos,
 void crsql_freeColumnInfoContents(crsql_ColumnInfo *columnInfo);
 void crsql_freeTableInfo(crsql_TableInfo *tableInfo);
 
+// TODO: this should be pullTableInfo
 int crsql_getTableInfo(sqlite3 *db, const char *tblName,
                        crsql_TableInfo **pTableInfo, char **pErrMsg);
 

--- a/core/src/util.c
+++ b/core/src/util.c
@@ -324,7 +324,10 @@ char *crsql_getDbVersionUnionQuery(int numRows, char **tableNames) {
 
   // compose the final query
   // and update the pointer to the string to point to it.
-  ret = sqlite3_mprintf("SELECT max(version) as version FROM (%z)", unionsStr);
+  ret = sqlite3_mprintf(
+      "SELECT max(version) as version FROM (%z UNION SELECT value as version "
+      "FROM crsql_master WHERE key = 'pre_compact_dbversion')",
+      unionsStr);
   // %z frees unionsStr https://www.sqlite.org/printf.html#percentz
   return ret;
 }

--- a/core/src/util.test.c
+++ b/core/src/util.test.c
@@ -30,17 +30,23 @@ static void testGetVersionUnionQuery() {
   printf("GetVersionUnionQuery\n");
 
   query = crsql_getDbVersionUnionQuery(numRows_tc1, tableNames_tc1);
-  assert(strcmp(query,
-                "SELECT max(version) as version FROM (SELECT "
-                "max(__crsql_db_version) as version FROM \"foo\"  )") == 0);
+  assert(
+      strcmp(
+          query,
+          "SELECT max(version) as version FROM (SELECT max(__crsql_db_version) "
+          "as version FROM \"foo\"   UNION SELECT value as version FROM "
+          "crsql_master WHERE key = 'pre_compact_dbversion')") == 0);
   sqlite3_free(query);
 
   query = crsql_getDbVersionUnionQuery(numRows_tc2, tableNames_tc2);
-  assert(strcmp(query,
-                "SELECT max(version) as version FROM (SELECT "
-                "max(__crsql_db_version) as version FROM \"foo\" UNION SELECT "
-                "max(__crsql_db_version) as version FROM \"bar\" UNION SELECT "
-                "max(__crsql_db_version) as version FROM \"baz\"  )") == 0);
+  assert(
+      strcmp(
+          query,
+          "SELECT max(version) as version FROM (SELECT max(__crsql_db_version) "
+          "as version FROM \"foo\" UNION SELECT max(__crsql_db_version) as "
+          "version FROM \"bar\" UNION SELECT max(__crsql_db_version) as "
+          "version FROM \"baz\"   UNION SELECT value as version FROM "
+          "crsql_master WHERE key = 'pre_compact_dbversion')") == 0);
   sqlite3_free(query);
 
   printf("\t\e[0;32mSuccess\e[0m\n");

--- a/py/correctness/notes.md
+++ b/py/correctness/notes.md
@@ -1,3 +1,3 @@
 pip3 install -e .
 
-EXPORT pythonpath=./src && pytest -s
+EXPORT PYTHONPATH=./src && pytest -s

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -126,12 +126,6 @@ def test_backfill_col_add():
     # Given we only migrate against compatible schema versions there's no need to create
     # a record of a default value. The other node will have the same default or, if they wrote a value,
     # a value which takes precedence.
-    # TODO: test that this merging with default values works as expected.
-    # will we:
-    # a. allow the merge because no clock entry was found?
-    # b. fail becuase no clock entry was found?
-    # the test needs the _row_ to exist on both node but _columns_ to be missing metadata due
-    # to being set to defaults.
     assert (changes == [('todo', '1', 'name', "'cook'"),
                         ('todo', '1', 'complete', '0'),
                         ('todo', '1', 'list', "'home'")])
@@ -396,9 +390,6 @@ def test_add_col_through_12step():
                         ('foo', '3', 'age', '44', 2, 1, None)])
 
 
-# TODO: if we do optimize to not set columns with default values
-# then we could miss an insert of just the pk column.
-
 def test_pk_only_table_backfill():
     c = connect(":memory:")
     c.execute("CREATE TABLE foo (id PRIMARY KEY);")
@@ -535,6 +526,7 @@ def test_remove_col_from_pk():
     # TODO: this is wrong, right?
     # DB version for the first two rows should be 2.....
     # Why is it 1 here?
+    # The first two rows would be re-created, no?
     assert (changes == [('foo', '1', 'c', '3', 1, 1, None),
                         ('foo', '4', 'c', '6', 1, 1, None),
                         ('foo', '1', 'b', '2', 2, 1, None),

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -502,11 +502,14 @@ def test_remove_rows_on_alter():
     assert (changes == [])
 
 
-# TODO: this doesn't work at the moment. We do not have a way to diff
-# table contents.
-# This is the case where:
-# User modifies existing cells of existing rows during a migration with no changes
-# to the schemas of those cells.
+# TODO: this doesn't work at the moment and will not work until
+# we have a way to diff tables.
+# The workaround here would be:
+# 1. make the changes to the schema between begin and commit alter
+# 2. after committing the alter, do changes of values
+# So we should simply publish some rules on migrations:
+# 1. Do _schema modifications_ in begin/commit alter
+# 2. Do _data modifications_ after commit alter
 def test_change_existing_values_on_alter():
     None
 

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -169,11 +169,6 @@ def test_backfill_clocks_on_rename():
 
 
 def test_delete_sentinels_not_lost():
-    # not lost after alter
-    # nor lost on crr re-application
-    # pk only / create
-    # delete
-    # records
     c = setup_alter_test()
     c.execute("DELETE FROM todo WHERE id = 1;")
     c.commit()
@@ -399,7 +394,8 @@ def test_pk_only_table_backfill():
     c.commit()
 
     changes = c.execute(full_changes_query).fetchall()
-    # TODO: we fail to backfill pk only tables!!
+    assert (changes == [('foo', '1', '__crsql_pko', None, 1, 1, None),
+                        ('foo', '2', '__crsql_pko', None, 1, 1, None)])
 
 
 # Imagine the case where we have a table:
@@ -481,7 +477,7 @@ def test_rename_pk_column():
     None
 
 
-def test_changing_primary_key_columns():
+def test_changing_values_in_primary_key_columns():
 
     # sqlite doesn't allow altering primary key def in an existing schema. Not even renames.
     # def test_clock_nuke_on_pk_schema_alter():

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -195,6 +195,7 @@ def test_delete_sentinels_not_lost():
     c.commit()
 
     changes = c.execute(changes_query).fetchall()
+    pprint.pprint(changes)
     assert (changes == [('todo', '1', '__crsql_del', None),
                         ('todo', '1', '__crsql_del', None),
                         ('todo', '1', '__crsql_del', None)])
@@ -487,7 +488,7 @@ def test_remove_rows_on_alter():
 
     changes = c.execute(full_changes_query).fetchall()
     # TODO: db version is wrong here. Should be 2, no?
-    # TODO: clock tabl itself should be cleared too!
+    # TODO: clock table itself should be cleared too!
     assert (changes == [('foo', '1', '__crsql_del', None, 1, 1, None),
                         ('foo', '3', '__crsql_del', None, 1, 1, None)])
 

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -377,8 +377,10 @@ def test_add_col_through_12step():
 
     changes = c.execute(full_changes_query).fetchall()
     assert (changes == [('foo', '3', 'name', 'NULL', 1, 1, None),
+                        # New row (22) appropriately gets new db version
                         ('foo', '22', 'name', "'baz'", 2, 1, None),
                         ('foo', '22', 'age', '33', 2, 1, None),
+                        # age was updated to a new value during migration so db_version appropriately incremented
                         ('foo', '3', 'age', '44', 2, 1, None)])
 
 

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -34,7 +34,6 @@ def test_c1_3_quoted_identifiers():
 
 def test_c1_c5_compound_primary_key():
     c = connect(":memory:")
-    # TODO: this was a silent failure when `create` as typoed
     c.execute("create table foo (a, b, c, primary key (a, b))")
     c.execute("select crsql_as_crr('foo')")
 
@@ -523,14 +522,11 @@ def test_remove_col_from_pk():
     c.commit()
 
     changes = c.execute(full_changes_query).fetchall()
-    # TODO: this is wrong, right?
-    # DB version for the first two rows should be 2.....
-    # Why is it 1 here?
-    # The first two rows would be re-created, no?
-    assert (changes == [('foo', '1', 'c', '3', 1, 1, None),
-                        ('foo', '4', 'c', '6', 1, 1, None),
-                        ('foo', '1', 'b', '2', 2, 1, None),
-                        ('foo', '4', 'b', '5', 2, 1, None)])
+    assert (changes == [('foo', '1', 'b', '2', 2, 1, None),
+                        ('foo', '1', 'c', '3', 2, 1, None),
+                        ('foo', '4', 'b', '5', 2, 1, None),
+                        ('foo', '4', 'c', '6', 2, 1, None)])
+
     None
 
 


### PR DESCRIPTION
- do not backfill metadata for default values in a migration
- default values, that are not explicitly set by an update/insert, always lose in a tie
- handle when primary key memberships is changed during a migration
- handle when rows are removed in a migration
- handle when rows are added in a migration
- support two notions of migration process:
  - schema migration: does not move db version forward. This is any operation done between begin and commit alter.
  - data migration: data modifications after commit_alter. These operation will move db_version for the new writes. Moving these operations before commit_alter will not move the db version.

Doing data migrations in the schema migration phase is useful when you know that a migration will leave nodes in a consistent state and not require replicating any rows (or columns) that were touched in the migration to other nodes.