### PR TITLE
implement rowid properly for crsql_changes

### DIFF
--- a/core/src/changes-vtab-read.c
+++ b/core/src/changes-vtab-read.c
@@ -21,7 +21,8 @@ char *crsql_changesQueryForTable(crsql_TableInfo *tableInfo) {
       __crsql_col_name as cid,\
       __crsql_col_version as col_vrsn,\
       __crsql_db_version as db_vrsn,\
-      __crsql_site_id as site_id\
+      __crsql_site_id as site_id,\
+      _rowid_\
     FROM \"%s__crsql_clock\"",
       tableInfo->tblName, crsql_quoteConcat(tableInfo->pks, tableInfo->pksLen),
       tableInfo->tblName);
@@ -72,7 +73,8 @@ char *crsql_changesUnionQuery(crsql_TableInfo **tableInfos, int tableInfosLen,
 
   // compose the final query
   return sqlite3_mprintf(
-      "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (%z) %s%s ORDER "
+      "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id, _rowid_ FROM (%z) "
+      "%s%s ORDER "
       "BY "
       "db_vrsn, tbl ASC",
       unionsStr, idxStr != 0 && strlen(idxStr) > 0 ? "WHERE " : "",

--- a/core/src/changes-vtab-read.h
+++ b/core/src/changes-vtab-read.h
@@ -15,6 +15,8 @@ char *crsql_changesQueryForTable(crsql_TableInfo *tableInfo);
 #define COL_VRSN 3
 #define DB_VRSN 4
 #define SITE_ID 5
+#define CHANGES_ROWID 6
+
 char *crsql_changesUnionQuery(crsql_TableInfo **tableInfos, int tableInfosLen,
                               const char *idxStr);
 char *crsql_rowPatchDataQuery(sqlite3 *db, crsql_TableInfo *tblInfo,

--- a/core/src/changes-vtab-read.test.c
+++ b/core/src/changes-vtab-read.test.c
@@ -29,8 +29,8 @@ static void testChangesQueryForTable() {
                 "SELECT      \'foo\' as tbl,      quote(\"a\") as pks,      "
                 "__crsql_col_name as cid,      __crsql_col_version as "
                 "col_vrsn,      __crsql_db_version as db_vrsn,      "
-                "__crsql_site_id as site_id    FROM \"foo__crsql_clock\"") ==
-         0);
+                "__crsql_site_id as site_id,      _rowid_    FROM "
+                "\"foo__crsql_clock\"") == 0);
   sqlite3_free(query);
 
   printf("\t\e[0;32mSuccess\e[0m\n");
@@ -62,28 +62,32 @@ static void testChangesUnionQuery() {
   char *query = crsql_changesUnionQuery(tblInfos, 2, "");
   assert(
       strcmp(query,
-             "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (SELECT    "
+             "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id, _rowid_ FROM "
+             "(SELECT    "
              "  'foo' as tbl,      quote(\"a\") as pks,      __crsql_col_name "
              "as cid,      __crsql_col_version as col_vrsn,      "
-             "__crsql_db_version as db_vrsn,      __crsql_site_id as site_id   "
+             "__crsql_db_version as db_vrsn,      __crsql_site_id as site_id,  "
+             "    _rowid_   "
              " FROM \"foo__crsql_clock\" UNION SELECT      'bar' as tbl,      "
              "quote(\"x\") as pks,      __crsql_col_name as cid,      "
              "__crsql_col_version as col_vrsn,      __crsql_db_version as "
-             "db_vrsn,      __crsql_site_id as site_id    FROM "
+             "db_vrsn,      __crsql_site_id as site_id,      _rowid_    FROM "
              "\"bar__crsql_clock\")  ORDER BY db_vrsn, tbl ASC") == 0);
   sqlite3_free(query);
 
   query = crsql_changesUnionQuery(tblInfos, 2, "site_id IS ? AND db_vrsn > ?");
   assert(
       strcmp(query,
-             "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id FROM (SELECT    "
+             "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id, _rowid_ FROM "
+             "(SELECT    "
              "  'foo' as tbl,      quote(\"a\") as pks,      __crsql_col_name "
              "as cid,      __crsql_col_version as col_vrsn,      "
-             "__crsql_db_version as db_vrsn,      __crsql_site_id as site_id   "
+             "__crsql_db_version as db_vrsn,      __crsql_site_id as site_id,  "
+             "    _rowid_   "
              " FROM \"foo__crsql_clock\" UNION SELECT      'bar' as tbl,      "
              "quote(\"x\") as pks,      __crsql_col_name as cid,      "
              "__crsql_col_version as col_vrsn,      __crsql_db_version as "
-             "db_vrsn,      __crsql_site_id as site_id    FROM "
+             "db_vrsn,      __crsql_site_id as site_id,      _rowid_    FROM "
              "\"bar__crsql_clock\") WHERE site_id IS ? AND db_vrsn > ? ORDER "
              "BY db_vrsn, tbl ASC") == 0);
   sqlite3_free(query);

--- a/core/src/changes-vtab-rowid.test.c
+++ b/core/src/changes-vtab-rowid.test.c
@@ -1,0 +1,114 @@
+/**
+ * Test that:
+ * 1. The rowid we return for a row on insert matches the rowid we get for it on
+ * read
+ * 2. That we can query the vtab by rowid??
+ * 3. The returned rowid matches the rowid used in a point query by rowid
+ * 4.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "crsqlite.h"
+
+int crsql_close(sqlite3 *db);
+
+// static void testRowidForInsert() {
+//   printf("RowidForInsert\n");
+
+//   sqlite3 *db;
+//   int rc;
+//   rc = sqlite3_open(":memory:", &db);
+
+//   rc = sqlite3_exec(db, "CREATE TABLE foo (a primary key, b);", 0, 0, 0);
+//   rc += sqlite3_exec(db, "SELECT crsql_as_crr('foo');", 0, 0, 0);
+//   assert(rc == SQLITE_OK);
+
+//   char *zSql =
+//       "INSERT INTO crsql_changes ([table], pk, cid, val, col_version, "
+//       "db_version) "
+//       "VALUES "
+//       "('foo', '1', 'b', '1', 1, 1) RETURNING _rowid_;";
+//   sqlite3_stmt *pStmt;
+//   rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+//   assert(rc == SQLITE_OK);
+//   assert(sqlite3_step(pStmt) == SQLITE_ROW);
+//   printf("rowid: %d\n", sqlite3_column_int64(pStmt, 0));
+//   assert(sqlite3_column_int64(pStmt, 0) == 1);
+//   sqlite3_finalize(pStmt);
+
+//   // TODO: make extra crr tables and check their slab allotments and returned
+//   // rowids
+
+//   crsql_close(db);
+//   printf("\t\e[0;32mSuccess\e[0m\n");
+// }
+
+static void testRowidsForReads() {
+  printf("RowidForReads\n");
+
+  sqlite3 *db;
+  int rc;
+  rc = sqlite3_open(":memory:", &db);
+
+  rc = sqlite3_exec(db, "CREATE TABLE foo (a primary key, b);", 0, 0, 0);
+  rc += sqlite3_exec(db, "SELECT crsql_as_crr('foo');", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+  sqlite3_exec(db, "INSERT INTO foo VALUES (1,2);", 0, 0, 0);
+  sqlite3_exec(db, "INSERT INTO foo VALUES (2,3);", 0, 0, 0);
+
+  char *zSql = "SELECT _rowid_ FROM crsql_changes";
+  sqlite3_stmt *pStmt;
+  rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  assert(rc == SQLITE_OK);
+  assert(sqlite3_step(pStmt) == SQLITE_ROW);
+  assert(sqlite3_column_int64(pStmt, 0) == 1);
+  assert(sqlite3_step(pStmt) == SQLITE_ROW);
+  assert(sqlite3_column_int64(pStmt, 0) == 2);
+  sqlite3_finalize(pStmt);
+
+  rc = sqlite3_exec(db, "CREATE TABLE bar (a primary key, b)", 0, 0, 0);
+  rc += sqlite3_exec(db, "SELECT crsql_as_crr('bar');", 0, 0, 0);
+  rc += sqlite3_exec(db, "INSERT INTO bar VALUES (1,2);", 0, 0, 0);
+  rc += sqlite3_exec(db, "INSERT INTO bar VALUES (2,3);", 0, 0, 0);
+
+  rc += sqlite3_exec(db, "CREATE TABLE baz (a primary key, b)", 0, 0, 0);
+  rc += sqlite3_exec(db, "SELECT crsql_as_crr('baz');", 0, 0, 0);
+  rc += sqlite3_exec(db, "INSERT INTO baz VALUES (1,2);", 0, 0, 0);
+  rc += sqlite3_exec(db, "INSERT INTO baz VALUES (2,3);", 0, 0, 0);
+
+  assert(rc == SQLITE_OK);
+
+  sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 1);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 2);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 1 * ROWID_SLAB_SIZE + 1);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 1 * ROWID_SLAB_SIZE + 2);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 2 * ROWID_SLAB_SIZE + 1);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 2 * ROWID_SLAB_SIZE + 2);
+  sqlite3_finalize(pStmt);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+// static void testInsertRowidMatchesReadRowid() {
+//   printf("RowidForInsertMatchesRowidForRead\n");
+//   printf("\t\e[0;32mSuccess\e[0m\n");
+// }
+
+void crsqlChangesVtabRowidTestSuite() {
+  printf("\e[47m\e[1;30mSuite: crsql_changesVtabRowid\e[0m\n");
+  // testRowidForInsert();
+  testRowidsForReads();
+  // testInsertRowidMatchesReadRowid();
+}

--- a/core/src/changes-vtab-write.c
+++ b/core/src/changes-vtab-write.c
@@ -123,11 +123,11 @@ int crsql_checkForLocalDelete(sqlite3 *db, const char *tblName,
   return SQLITE_OK;
 }
 
-int crsql_setWinnerClock(sqlite3 *db, crsql_TableInfo *tblInfo,
-                         const char *pkIdentifierList, const char *pkValsStr,
-                         const char *insertColName, sqlite3_int64 insertColVrsn,
-                         sqlite3_int64 insertDbVrsn, const void *insertSiteId,
-                         int insertSiteIdLen) {
+sqlite3_int64 crsql_setWinnerClock(
+    sqlite3 *db, crsql_TableInfo *tblInfo, const char *pkIdentifierList,
+    const char *pkValsStr, const char *insertColName,
+    sqlite3_int64 insertColVrsn, sqlite3_int64 insertDbVrsn,
+    const void *insertSiteId, int insertSiteIdLen) {
   int rc = SQLITE_OK;
   char *zSql = sqlite3_mprintf(
       "INSERT OR REPLACE INTO \"%s__crsql_clock\" \
@@ -138,7 +138,7 @@ int crsql_setWinnerClock(sqlite3 *db, crsql_TableInfo *tblInfo,
         %lld,\
         MAX(crsql_nextdbversion(), %lld),\
         ?\
-      )",
+      ) RETURNING _rowid_",
       tblInfo->tblName, pkIdentifierList, pkValsStr, insertColName,
       insertColVrsn, insertDbVrsn);
 
@@ -148,7 +148,7 @@ int crsql_setWinnerClock(sqlite3 *db, crsql_TableInfo *tblInfo,
 
   if (rc != SQLITE_OK) {
     sqlite3_finalize(pStmt);
-    return rc;
+    return -1;
   }
 
   if (insertSiteId == 0) {
@@ -159,33 +159,37 @@ int crsql_setWinnerClock(sqlite3 *db, crsql_TableInfo *tblInfo,
   }
 
   rc = sqlite3_step(pStmt);
-  sqlite3_finalize(pStmt);
 
-  if (rc == SQLITE_DONE) {
-    return SQLITE_OK;
+  if (rc == SQLITE_ROW) {
+    sqlite3_int64 rowid = sqlite3_column_int64(pStmt, 0);
+    sqlite3_finalize(pStmt);
+    return rowid;
   } else {
-    return SQLITE_ERROR;
+    sqlite3_finalize(pStmt);
+    return -1;
   }
 }
 
-int crsql_mergePkOnlyInsert(sqlite3 *db, crsql_TableInfo *tblInfo,
-                            const char *pkValsStr, const char *pkIdentifiers,
-                            sqlite3_int64 remoteColVersion,
-                            sqlite3_int64 remoteDbVersion,
-                            const void *remoteSiteId, int remoteSiteIdLen) {
+sqlite3_int64 crsql_mergePkOnlyInsert(sqlite3 *db, crsql_TableInfo *tblInfo,
+                                      const char *pkValsStr,
+                                      const char *pkIdentifiers,
+                                      sqlite3_int64 remoteColVersion,
+                                      sqlite3_int64 remoteDbVersion,
+                                      const void *remoteSiteId,
+                                      int remoteSiteIdLen) {
   char *zSql = sqlite3_mprintf("INSERT OR IGNORE INTO \"%s\" (%s) VALUES (%s)",
                                tblInfo->tblName, pkIdentifiers, pkValsStr);
   int rc = sqlite3_exec(db, SET_SYNC_BIT, 0, 0, 0);
   if (rc != SQLITE_OK) {
     sqlite3_free(zSql);
-    return rc;
+    return -1;
   }
 
   rc = sqlite3_exec(db, zSql, 0, 0, 0);
   sqlite3_free(zSql);
   sqlite3_exec(db, CLEAR_SYNC_BIT, 0, 0, 0);
   if (rc != SQLITE_OK) {
-    return rc;
+    return -1;
   }
 
   // TODO: if insert was ignored, no reason to change clock
@@ -194,24 +198,25 @@ int crsql_mergePkOnlyInsert(sqlite3 *db, crsql_TableInfo *tblInfo,
                               remoteDbVersion, remoteSiteId, remoteSiteIdLen);
 }
 
-int crsql_mergeDelete(sqlite3 *db, crsql_TableInfo *tblInfo,
-                      const char *pkWhereList, const char *pkValsStr,
-                      const char *pkIdentifiers, sqlite3_int64 remoteColVersion,
-                      sqlite3_int64 remoteDbVersion, const void *remoteSiteId,
-                      int remoteSiteIdLen) {
+sqlite3_int64 crsql_mergeDelete(sqlite3 *db, crsql_TableInfo *tblInfo,
+                                const char *pkWhereList, const char *pkValsStr,
+                                const char *pkIdentifiers,
+                                sqlite3_int64 remoteColVersion,
+                                sqlite3_int64 remoteDbVersion,
+                                const void *remoteSiteId, int remoteSiteIdLen) {
   char *zSql = sqlite3_mprintf("DELETE FROM \"%s\" WHERE %s", tblInfo->tblName,
                                pkWhereList);
   int rc = sqlite3_exec(db, SET_SYNC_BIT, 0, 0, 0);
   if (rc != SQLITE_OK) {
     sqlite3_free(zSql);
-    return rc;
+    return -1;
   }
 
   rc = sqlite3_exec(db, zSql, 0, 0, 0);
   sqlite3_free(zSql);
   sqlite3_exec(db, CLEAR_SYNC_BIT, 0, 0, 0);
   if (rc != SQLITE_OK) {
-    return rc;
+    return -1;
   }
 
   return crsql_setWinnerClock(db, tblInfo, pkIdentifiers, pkValsStr,
@@ -328,27 +333,35 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
   char *pkIdentifierList =
       crsql_asIdentifierList(tblInfo->pks, tblInfo->pksLen, 0);
   if (isDelete) {
-    rc = crsql_mergeDelete(db, tblInfo, pkWhereList, pkValsStr,
-                           pkIdentifierList, insertColVrsn, insertDbVrsn,
-                           insertSiteId, insertSiteIdLen);
+    sqlite3_int64 rowid = crsql_mergeDelete(
+        db, tblInfo, pkWhereList, pkValsStr, pkIdentifierList, insertColVrsn,
+        insertDbVrsn, insertSiteId, insertSiteIdLen);
 
     sqlite3_free(pkWhereList);
     sqlite3_free(pkValsStr);
     sqlite3_free(pkIdentifierList);
-    // TODO: set rowid via slab algorithm here
-    return rc;
+    if (rowid == -1) {
+      *errmsg = sqlite3_mprintf("Failed inserting changeset");
+      return SQLITE_ERROR;
+    }
+    *pRowid = crsql_slabRowid(tblInfoIndex, rowid);
+    return SQLITE_OK;
   }
 
   if (isPkOnly ||
       !crsql_columnExists(insertColName, tblInfo->nonPks, tblInfo->nonPksLen)) {
-    rc = crsql_mergePkOnlyInsert(db, tblInfo, pkValsStr, pkIdentifierList,
-                                 insertColVrsn, insertDbVrsn, insertSiteId,
-                                 insertSiteIdLen);
+    sqlite3_int64 rowid = crsql_mergePkOnlyInsert(
+        db, tblInfo, pkValsStr, pkIdentifierList, insertColVrsn, insertDbVrsn,
+        insertSiteId, insertSiteIdLen);
     sqlite3_free(pkWhereList);
     sqlite3_free(pkValsStr);
     sqlite3_free(pkIdentifierList);
-    // TODO: set rowid via slab algorithm here
-    return rc;
+    if (rowid == -1) {
+      *errmsg = sqlite3_mprintf("Failed inserting changeset");
+      return SQLITE_ERROR;
+    }
+    *pRowid = crsql_slabRowid(tblInfoIndex, rowid);
+    return SQLITE_OK;
   }
 
   char **sanitizedInsertVal =
@@ -386,7 +399,7 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
       "INSERT INTO \"%w\" (%s, \"%w\")\
       VALUES (%s, %s)\
       ON CONFLICT DO UPDATE\
-      SET \"%w\" = %s RETURNING _rowid_",
+      SET \"%w\" = %s",
       tblInfo->tblName, pkIdentifierList, insertColName, pkValsStr,
       sanitizedInsertVal[0], insertColName, sanitizedInsertVal[0]);
 
@@ -403,21 +416,9 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
     return rc;
   }
 
-  sqlite3_stmt *pStmt = 0;
-  rc = sqlite3_prepare_v2(db, zSql, -1, &pStmt, 0);
+  rc = sqlite3_exec(db, zSql, 0, 0, errmsg);
   sqlite3_free(zSql);
-  sqlite3_int64 rowid = 0;
-  if (rc == SQLITE_OK) {
-    rc = sqlite3_step(pStmt);
-    if (rc == SQLITE_ROW) {
-      rowid = sqlite3_column_int64(pStmt, 0);
-      rc = SQLITE_OK;
-    } else {
-      rc = SQLITE_ERROR;
-    }
-  }
   sqlite3_exec(db, CLEAR_SYNC_BIT, 0, 0, 0);
-  sqlite3_finalize(pStmt);
 
   if (rc != SQLITE_OK) {
     sqlite3_free(pkValsStr);
@@ -426,18 +427,17 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
     return rc;
   }
 
-  rc = crsql_setWinnerClock(db, tblInfo, pkIdentifierList, pkValsStr,
-                            insertColName, insertColVrsn, insertDbVrsn,
-                            insertSiteId, insertSiteIdLen);
+  sqlite3_int64 rowid = crsql_setWinnerClock(
+      db, tblInfo, pkIdentifierList, pkValsStr, insertColName, insertColVrsn,
+      insertDbVrsn, insertSiteId, insertSiteIdLen);
   sqlite3_free(pkIdentifierList);
   sqlite3_free(pkValsStr);
 
-  if (rc != SQLITE_OK) {
+  if (rowid == -1) {
     *errmsg = sqlite3_mprintf("Failed updating winner clock");
-    return rc;
+    return SQLITE_ERROR;
   }
 
-  // TODO: slab algo for merge pkonly and merge delete??
   *pRowid = crsql_slabRowid(tblInfoIndex, rowid);
   pTab->pExtData->rowsImpacted += 1;
   return rc;

--- a/core/src/changes-vtab.h
+++ b/core/src/changes-vtab.h
@@ -103,6 +103,9 @@ struct crsql_Changes_cursor {
 
   sqlite3_int64 dbVersion;
   int rowType;
+
+  sqlite3_int64 changesRowid;
+  int tblInfoIdx;
 };
 
 #endif

--- a/core/src/tableinfo.c
+++ b/core/src/tableinfo.c
@@ -298,9 +298,7 @@ int crsql_indexofTableInfo(crsql_TableInfo **tblInfos, int len,
   return -1;
 }
 
-sqlite3_int64 crsql_slabRowid(crsql_TableInfo **tblInfos, int len,
-                              const char *tblName, sqlite3_int64 rowid) {
-  int idx = crsql_indexofTableInfo(tblInfos, len, tblName);
+sqlite3_int64 crsql_slabRowid(int idx, sqlite3_int64 rowid) {
   if (idx < 0) {
     return -1;
   }

--- a/core/src/tableinfo.c
+++ b/core/src/tableinfo.c
@@ -287,6 +287,28 @@ crsql_TableInfo *crsql_findTableInfo(crsql_TableInfo **tblInfos, int len,
   return 0;
 }
 
+int crsql_indexofTableInfo(crsql_TableInfo **tblInfos, int len,
+                           const char *tblName) {
+  for (int i = 0; i < len; ++i) {
+    if (strcmp(tblInfos[i]->tblName, tblName) == 0) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+sqlite3_int64 crsql_slabRowid(crsql_TableInfo **tblInfos, int len,
+                              const char *tblName, sqlite3_int64 rowid) {
+  int idx = crsql_indexofTableInfo(tblInfos, len, tblName);
+  if (idx < 0) {
+    return -1;
+  }
+
+  sqlite3_int64 modulo = rowid % ROWID_SLAB_SIZE;
+  return idx * ROWID_SLAB_SIZE + modulo;
+}
+
 /**
  * Pulls all table infos for all crrs present in the database.
  * Run once at vtab initialization -- see docs on crsql_Changes_vtab

--- a/core/src/tableinfo.h
+++ b/core/src/tableinfo.h
@@ -51,8 +51,7 @@ crsql_TableInfo *crsql_findTableInfo(crsql_TableInfo **tblInfos, int len,
                                      const char *tblName);
 int crsql_indexofTableInfo(crsql_TableInfo **tblInfos, int len,
                            const char *tblName);
-sqlite3_int64 crsql_slabRowid(crsql_TableInfo **tblInfos, int len,
-                              const char *tblName, sqlite3_int64 rowid);
+sqlite3_int64 crsql_slabRowid(int idx, sqlite3_int64 rowid);
 char *crsql_quoteConcat(crsql_ColumnInfo *cols, int len);
 int crsql_pullAllTableInfos(sqlite3 *db, crsql_TableInfo ***pzpTableInfos,
                             int *rTableInfosLen, char **errmsg);

--- a/core/src/tableinfo.h
+++ b/core/src/tableinfo.h
@@ -7,6 +7,9 @@ SQLITE_EXTENSION_INIT3
 #include <ctype.h>
 #include <stddef.h>
 
+// 10 trillion = 10,000,000,000,000
+#define ROWID_SLAB_SIZE 10000000000000
+
 typedef struct crsql_ColumnInfo crsql_ColumnInfo;
 struct crsql_ColumnInfo {
   int cid;
@@ -46,6 +49,10 @@ char *crsql_asIdentifierList(crsql_ColumnInfo *in, size_t inlen, char *prefix);
 void crsql_freeAllTableInfos(crsql_TableInfo **tableInfos, int len);
 crsql_TableInfo *crsql_findTableInfo(crsql_TableInfo **tblInfos, int len,
                                      const char *tblName);
+int crsql_indexofTableInfo(crsql_TableInfo **tblInfos, int len,
+                           const char *tblName);
+sqlite3_int64 crsql_slabRowid(crsql_TableInfo **tblInfos, int len,
+                              const char *tblName, sqlite3_int64 rowid);
 char *crsql_quoteConcat(crsql_ColumnInfo *cols, int len);
 int crsql_pullAllTableInfos(sqlite3 *db, crsql_TableInfo ***pzpTableInfos,
                             int *rTableInfosLen, char **errmsg);

--- a/core/src/tableinfo.test.c
+++ b/core/src/tableinfo.test.c
@@ -282,6 +282,8 @@ static void testSlabRowid() {
   assert(barSlabRowid == 2 + ROWID_SLAB_SIZE);
   assert(bazSlabRowid == 3 + ROWID_SLAB_SIZE * 2);
 
+  crsql_freeAllTableInfos(tblInfos, tblInfosLen);
+
   crsql_close(db);
   printf("\t\e[0;32mSuccess\e[0m\n");
 }

--- a/core/src/tableinfo.test.c
+++ b/core/src/tableinfo.test.c
@@ -261,9 +261,9 @@ static void testSlabRowid() {
   assert(rc == SQLITE_OK);
 
   // now get the slab rowid for each table
-  sqlite3_int64 fooSlabRowid = crsql_slabRowid(tblInfos, tblInfosLen, "foo", 1);
-  sqlite3_int64 barSlabRowid = crsql_slabRowid(tblInfos, tblInfosLen, "bar", 2);
-  sqlite3_int64 bazSlabRowid = crsql_slabRowid(tblInfos, tblInfosLen, "baz", 3);
+  sqlite3_int64 fooSlabRowid = crsql_slabRowid(0, 1);
+  sqlite3_int64 barSlabRowid = crsql_slabRowid(1, 2);
+  sqlite3_int64 bazSlabRowid = crsql_slabRowid(2, 3);
 
   // now assert each one
   assert(fooSlabRowid == 1);
@@ -271,16 +271,12 @@ static void testSlabRowid() {
   assert(bazSlabRowid == 3 + ROWID_SLAB_SIZE * 2);
 
   // now test the modulo
-  assert(crsql_slabRowid(tblInfos, tblInfosLen, "foo", ROWID_SLAB_SIZE) == 0);
-  assert(crsql_slabRowid(tblInfos, tblInfosLen, "foo", ROWID_SLAB_SIZE + 1) ==
-         1);
+  assert(crsql_slabRowid(0, ROWID_SLAB_SIZE) == 0);
+  assert(crsql_slabRowid(0, ROWID_SLAB_SIZE + 1) == 1);
 
-  fooSlabRowid =
-      crsql_slabRowid(tblInfos, tblInfosLen, "foo", ROWID_SLAB_SIZE + 1);
-  barSlabRowid =
-      crsql_slabRowid(tblInfos, tblInfosLen, "bar", ROWID_SLAB_SIZE + 2);
-  bazSlabRowid =
-      crsql_slabRowid(tblInfos, tblInfosLen, "baz", ROWID_SLAB_SIZE * 2 + 3);
+  fooSlabRowid = crsql_slabRowid(0, ROWID_SLAB_SIZE + 1);
+  barSlabRowid = crsql_slabRowid(1, ROWID_SLAB_SIZE + 2);
+  bazSlabRowid = crsql_slabRowid(2, ROWID_SLAB_SIZE * 2 + 3);
 
   assert(fooSlabRowid == 1);
   assert(barSlabRowid == 2 + ROWID_SLAB_SIZE);

--- a/core/src/tableinfo.test.c
+++ b/core/src/tableinfo.test.c
@@ -237,6 +237,59 @@ static void testIsTableCompatible() {
   crsql_close(db);
 }
 
+static void testSlabRowid() {
+  printf("SlabRowid\n");
+  sqlite3 *db = 0;
+  char *errmsg = 0;
+  int rc = SQLITE_OK;
+
+  rc = sqlite3_open(":memory:", &db);
+  rc += sqlite3_exec(db, "CREATE TABLE foo (a PRIMARY KEY)", 0, 0, 0);
+  rc += sqlite3_exec(db, "CREATE TABLE bar (a PRIMARY KEY)", 0, 0, 0);
+  rc += sqlite3_exec(db, "CREATE TABLE baz (a PRIMARY KEY)", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  rc += sqlite3_exec(db, "SELECT crsql_as_crr('foo');", 0, 0, 0);
+  rc += sqlite3_exec(db, "SELECT crsql_as_crr('bar');", 0, 0, 0);
+  rc += sqlite3_exec(db, "SELECT crsql_as_crr('baz');", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  // now pull all table infos
+  crsql_TableInfo **tblInfos = 0;
+  int tblInfosLen = 0;
+  rc = crsql_pullAllTableInfos(db, &tblInfos, &tblInfosLen, &errmsg);
+  assert(rc == SQLITE_OK);
+
+  // now get the slab rowid for each table
+  sqlite3_int64 fooSlabRowid = crsql_slabRowid(tblInfos, tblInfosLen, "foo", 1);
+  sqlite3_int64 barSlabRowid = crsql_slabRowid(tblInfos, tblInfosLen, "bar", 2);
+  sqlite3_int64 bazSlabRowid = crsql_slabRowid(tblInfos, tblInfosLen, "baz", 3);
+
+  // now assert each one
+  assert(fooSlabRowid == 1);
+  assert(barSlabRowid == 2 + ROWID_SLAB_SIZE);
+  assert(bazSlabRowid == 3 + ROWID_SLAB_SIZE * 2);
+
+  // now test the modulo
+  assert(crsql_slabRowid(tblInfos, tblInfosLen, "foo", ROWID_SLAB_SIZE) == 0);
+  assert(crsql_slabRowid(tblInfos, tblInfosLen, "foo", ROWID_SLAB_SIZE + 1) ==
+         1);
+
+  fooSlabRowid =
+      crsql_slabRowid(tblInfos, tblInfosLen, "foo", ROWID_SLAB_SIZE + 1);
+  barSlabRowid =
+      crsql_slabRowid(tblInfos, tblInfosLen, "bar", ROWID_SLAB_SIZE + 2);
+  bazSlabRowid =
+      crsql_slabRowid(tblInfos, tblInfosLen, "baz", ROWID_SLAB_SIZE * 2 + 3);
+
+  assert(fooSlabRowid == 1);
+  assert(barSlabRowid == 2 + ROWID_SLAB_SIZE);
+  assert(bazSlabRowid == 3 + ROWID_SLAB_SIZE * 2);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
 void crsqlTableInfoTestSuite() {
   printf("\e[47m\e[1;30mSuite: crsql_tableInfo\e[0m\n");
 
@@ -245,5 +298,6 @@ void crsqlTableInfoTestSuite() {
   testFindTableInfo();
   testQuoteConcat();
   testIsTableCompatible();
+  testSlabRowid();
   // testPullAllTableInfos();
 }

--- a/core/src/tests.c
+++ b/core/src/tests.c
@@ -25,6 +25,7 @@ void crsqlExtDataTestSuite();
 void crsqlFractSuite();
 void crsqlIsCrrTestSuite();
 void rowsImpactedTestSuite();
+void crsqlChangesVtabRowidTestSuite();
 
 int main(int argc, char *argv[]) {
   char *suite = "all";
@@ -46,6 +47,7 @@ int main(int argc, char *argv[]) {
   SUITE("fract") crsqlFractSuite();
   SUITE("is_crr") crsqlIsCrrTestSuite();
   SUITE("rows_impacted") rowsImpactedTestSuite();
+  SUITE("rowid") crsqlChangesVtabRowidTestSuite();
 
   sqlite3_shutdown();
 }


### PR DESCRIPTION
Previously we did not return unique rowids for each row returned by crsql_changes. Now we do.

Note that _rowid_ is not stable as it is derived from sqlite _rowid_'s which are not stable.

> If the [rowid](https://www.sqlite.org/lang_createtable.html#rowid) is not aliased by [INTEGER PRIMARY KEY](https://www.sqlite.org/lang_createtable.html#rowid) then it is not persistent and might change. In particular the [VACUUM](https://www.sqlite.org/lang_vacuum.html) command will change rowids for tables that do not declare an INTEGER PRIMARY KEY. Therefore, applications should not normally access the rowid directly, but instead use an INTEGER PRIMARY KEY.

https://www.sqlite.org/rowidtable.html

but it will be stable between vacuums.