### PR TITLE
Revert "relax the constraint the columns must be optional or have def…

### DIFF
--- a/core/src/changes-vtab-write.c
+++ b/core/src/changes-vtab-write.c
@@ -392,9 +392,6 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
     return doesCidWin == 0 ? SQLITE_OK : SQLITE_ERROR;
   }
 
-  // TODO: this is wrong. we should
-  // be returning rowid from the _clock_ table!
-  // not base table!
   zSql = sqlite3_mprintf(
       "INSERT INTO \"%w\" (%s, \"%w\")\
       VALUES (%s, %s)\

--- a/core/src/tableinfo.test.c
+++ b/core/src/tableinfo.test.c
@@ -183,12 +183,13 @@ static void testIsTableCompatible() {
   assert(rc == 0);
   sqlite3_free(errmsg);
 
-  // not null and no dflt -- this is allowed
+  // not null and no dflt
   rc = sqlite3_exec(db, "CREATE TABLE buzz (a primary key, b NOT NULL)", 0, 0,
                     0);
   assert(rc == SQLITE_OK);
   rc = crsql_isTableCompatible(db, "buzz", &errmsg);
-  assert(rc == 1);
+  assert(rc == 0);
+  sqlite3_free(errmsg);
 
   // not null and dflt
   rc = sqlite3_exec(


### PR DESCRIPTION
…ault values"

Due to how we merge insertions we cannot relax these constraints yet. To relax these constraints we would need to gather all columns impacted by an insert and insert them all at once on initial creation.

see https://discord.com/channels/989870439897653248/989870440585494530/1110926517413888050

This reverts commit 5aebb64e5b4b2d3668c82dd00ad0e72da8a1124c.