### PR TITLE
keep referential equality if returned data from db did not change

### DIFF
--- a/scripts/update-pkgjson.sh
+++ b/scripts/update-pkgjson.sh
@@ -16,7 +16,7 @@ for pkg in "${pkgs[@]}"; do
   PACKAGE_EXISTS=$(jq -r --arg name "$NAME" '.dependencies | has($name)' package.json)
   if [ "$PACKAGE_EXISTS" = "true" ]; then
     if [[ $1 == "local" ]]; then
-      VERSION="local:$VERSION"
+      VERSION="link:$VERSION"
     fi
     # replace in package.json only if there is an entry for that package in the package.json
     jq --arg name "$NAME" --arg version "$VERSION" '.dependencies[$name] = $version' package.json > tmp.json && mv tmp.json package.json


### PR DESCRIPTION
This is an optimization for React to reduce re-renders when data did not change.

In the future, callbacks and queries will not even be made if the data didn't change. To be implemented in the LiveSQL layer.