### PR TITLE
Fix `crsql_automigrate` for cases where the `crsql` extension has been statically linked

### DIFF
--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -66,7 +66,7 @@ pub extern "C" fn sqlite3_crsqlcore_init(
     let rc = db
         .create_function_v2(
             "crsql_automigrate",
-            1,
+            -1,
             sqlite::UTF8,
             None,
             Some(crsql_automigrate),

--- a/core/rs/integration-check/tests/automigrate.rs
+++ b/core/rs/integration-check/tests/automigrate.rs
@@ -290,6 +290,151 @@ CREATE TABLE IF NOT EXISTS "redo_stack" (
     stmt.reset()?;
     stmt.step()?;
     assert_eq!(stmt.column_text(0)?, "migration complete");
+
+    // Now lets make change
+    let stmt = db.db.prepare_v2(
+        r#"
+SELECT crsql_automigrate(?)"#,
+    )?;
+    stmt.bind_text(
+        1,
+        r#"
+CREATE TABLE IF NOT EXISTS "deck" (
+"id" INTEGER primary key,
+"title",
+"created",
+"modified",
+"theme_id",
+"chosen_presenter"
+);
+
+CREATE TABLE IF NOT EXISTS "slide" (
+"id" INTEGER primary key,
+"deck_id",
+"order",
+"created",
+"modified",
+"x",
+"y",
+"z"
+);
+
+CREATE INDEX IF NOT EXISTS "slide_deck_id" ON "slide" ("deck_id", "order");
+
+CREATE TABLE IF NOT EXISTS "text_component" (
+"id" INTEGER primary key,
+"slide_id",
+"text",
+"styles",
+"x",
+"y",
+"width",
+"height"
+);
+
+CREATE TABLE IF NOT EXISTS "embed_component" ("id" primary key, "slide_id", "src", "x", "y", "width", "height");
+
+CREATE INDEX IF NOT EXISTS "embed_component_slide_id" ON "embed_component" ("slide_id");
+
+CREATE TABLE IF NOT EXISTS "shape_component" (
+"id" INTEGER primary key,
+"slide_id",
+"type",
+"props",
+"x",
+"y",
+"width",
+"height"
+);
+
+CREATE INDEX IF NOT EXISTS "shape_component_slide_id" ON "shape_component" ("slide_id");
+
+CREATE TABLE IF NOT EXISTS "line_component" ("id" primary key, "slide_id", "props");
+
+CREATE INDEX IF NOT EXISTS "line_component_slide_id" ON "line_component" ("slide_id");
+
+CREATE TABLE IF NOT EXISTS "line_point" ("id" primary key, "line_id", "x", "y");
+
+CREATE INDEX IF NOT EXISTS "line_point_line_id" ON "line_point" ("line_id");
+
+CREATE INDEX IF NOT EXISTS "text_component_slide_id" ON "text_component" ("slide_id");
+
+CREATE TABLE IF NOT EXISTS "theme" (
+"id" INTEGER primary key,
+"name",
+"bg_colorset",
+"fg_colorset",
+"fontset",
+"surface_color",
+"font_color"
+);
+
+CREATE TABLE IF NOT EXISTS "recent_color" (
+"color" INTEGER primary key,
+"last_used",
+"first_used",
+"theme_id"
+);
+
+CREATE TABLE IF NOT EXISTS "presenter" (
+"name" primary key,
+"available_transitions",
+"picked_transition"
+);
+
+SELECT crsql_as_crr('deck');
+
+SELECT crsql_as_crr('slide');
+
+SELECT crsql_fract_as_ordered('slide', 'order', 'deck_id');
+
+SELECT crsql_as_crr('text_component');
+
+SELECT crsql_as_crr('embed_component');
+
+SELECT crsql_as_crr('shape_component');
+
+SELECT crsql_as_crr('line_component');
+
+SELECT crsql_as_crr('line_point');
+
+SELECT crsql_as_crr('theme');
+
+SELECT crsql_as_crr('recent_color');
+
+SELECT crsql_as_crr('presenter');
+
+CREATE TABLE IF NOT EXISTS "selected_slide" (
+"deck_id",
+"slide_id",
+primary key ("deck_id", "slide_id")
+);
+
+CREATE TABLE IF NOT EXISTS "selected_component" (
+"slide_id",
+"component_id",
+"component_type",
+primary key ("slide_id", "component_id")
+);
+
+CREATE TABLE IF NOT EXISTS "undo_stack" (
+"deck_id",
+"operation",
+"order",
+primary key ("deck_id", "order")
+);
+
+CREATE TABLE IF NOT EXISTS "redo_stack" (
+"deck_id",
+"operation",
+"order",
+primary key ("deck_id", "order")
+);"#,
+        sqlite::Destructor::STATIC,
+    )?;
+    stmt.step()?;
+    assert_eq!(stmt.column_text(0)?, "migration complete");
+
     Ok(())
 }
 

--- a/js/build-wasm-dbg.sh
+++ b/js/build-wasm-dbg.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# cargo clean in core/rs/bundle
+
+mkdir -p packages/crsqlite-wasm/dist
+cd deps/emsdk
+./emsdk install latest
+./emsdk activate latest
+source ./emsdk_env.sh
+cd ../wa-sqlite
+make debug
+cp debug/crsqlite.wasm ../../packages/crsqlite-wasm/dist/crsqlite.wasm
+cp debug/crsqlite.mjs ../../packages/crsqlite-wasm/src/crsqlite.mjs

--- a/js/packages/browser-tests/cypress/component/automigrate.cy.ts
+++ b/js/packages/browser-tests/cypress/component/automigrate.cy.ts
@@ -15,6 +15,9 @@ describe("automigrate.cy.ts", () => {
       CREATE TABLE IF NOT EXISTS test (id PRIMARY KEY, name TEXT, time INTEGER);
       SELECT crsql_as_crr('test');
     `;
-    await db.exec(`SELECT crsql_automigrate(?);`, [updatedSchema]);
+    await db.exec(
+      /*sql*/ `SELECT crsql_automigrate(?, 'SELECT crsql_finalize();');`,
+      [updatedSchema]
+    );
   });
 });

--- a/js/packages/browser-tests/cypress/component/automigrate.cy.ts
+++ b/js/packages/browser-tests/cypress/component/automigrate.cy.ts
@@ -1,0 +1,20 @@
+import sqliteWasm from "@vlcn.io/crsqlite-wasm";
+// @ts-ignore
+import wasmUrl from "@vlcn.io/crsqlite-wasm/crsqlite.wasm?url";
+const crsqlite = await sqliteWasm((file) => wasmUrl);
+
+describe("automigrate.cy.ts", () => {
+  it("handles column addition", async () => {
+    const db = await crsqlite.open();
+    const schema = /*sql*/ `
+      CREATE TABLE IF NOT EXISTS test (id PRIMARY KEY, name TEXT);
+      SELECT crsql_as_crr('test');
+    `;
+    await db.exec(schema);
+    const updatedSchema = /*sql*/ `
+      CREATE TABLE IF NOT EXISTS test (id PRIMARY KEY, name TEXT, time INTEGER);
+      SELECT crsql_as_crr('test');
+    `;
+    await db.exec(`SELECT crsql_automigrate(?);`, [updatedSchema]);
+  });
+});

--- a/js/packages/crsqlite-wasm/src/DB.ts
+++ b/js/packages/crsqlite-wasm/src/DB.ts
@@ -98,7 +98,10 @@ export class DB implements DBAsync {
         }
         await tx.exec(schemaContent);
       } else {
-        await tx.exec(`SELECT crsql_automigrate(?)`, [schemaContent]);
+        await tx.exec(
+          `SELECT crsql_automigrate(?, 'SELECT crsql_finalize();')`,
+          [schemaContent]
+        );
       }
       await tx.exec(
         `INSERT OR REPLACE INTO crsql_master (key, value) VALUES (?, ?)`,

--- a/js/packages/node-tests/src/__tests__/automigrate.test.ts
+++ b/js/packages/node-tests/src/__tests__/automigrate.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "vitest";
+import crsqlite from "@vlcn.io/crsqlite-allinone";
+
+test("automigrate", () => {
+  const db = crsqlite.open();
+  const schema = /*sql*/ `
+      CREATE TABLE IF NOT EXISTS test (id PRIMARY KEY, name TEXT);
+      SELECT crsql_as_crr('test');
+    `;
+  db.exec(`SELECT crsql_automigrate(?);`, [schema]);
+  const updatedSchema = /*sql*/ `
+      CREATE TABLE IF NOT EXISTS test (id PRIMARY KEY, name TEXT, time INTEGER);
+      SELECT crsql_as_crr('test');
+    `;
+  db.exec(`SELECT crsql_automigrate(?);`, [updatedSchema]);
+});


### PR DESCRIPTION
If the extension is statically linked then the in-memory DB that is opened to facilitate auto-migrations will have the extension loaded.

When this is the case, we must do extra cleanup of the in-memory DB.

This PR exposes a second arg to `crsql_automigrate` which allows the user to pass custom cleanup logic.