### PR TITLE
compile in the bytecode extension to the sqlite cli

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -149,6 +149,7 @@ $(TARGET_SQLITE3): $(prefix) $(TARGET_SQLITE3_EXTRA_C) $(rs_lib_dbg_static_cpy) 
 	-DSQLITE_THREADSAFE=0 \
 	-DSQLITE_OMIT_LOAD_EXTENSION=1 \
 	-DSQLITE_EXTRA_INIT=core_init \
+	-DSQLITE_ENABLE_BYTECODE_VTAB \
 	-I./src/ -I./src/sqlite \
 	$(TARGET_SQLITE3_EXTRA_C) src/sqlite/shell.c $(ext_files) $(rs_lib_dbg_static_cpy) \
 	$(LDLIBS) -o $@


### PR DESCRIPTION
this'll allow us to explore whether or not a byte code representation of the query is enough for our reactivity layer or if we need to pull in a query parser

https://fly.io/blog/sqlite-virtual-machine/