### PR TITLE
Count deletes towards rows impacted

### DIFF
--- a/core/src/changes-vtab-write.c
+++ b/core/src/changes-vtab-write.c
@@ -346,6 +346,7 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
       return SQLITE_ERROR;
     }
     *pRowid = crsql_slabRowid(tblInfoIndex, rowid);
+    pTab->pExtData->rowsImpacted += 1;
     return SQLITE_OK;
   }
 
@@ -362,6 +363,7 @@ int crsql_mergeInsert(sqlite3_vtab *pVTab, int argc, sqlite3_value **argv,
       return SQLITE_ERROR;
     }
     *pRowid = crsql_slabRowid(tblInfoIndex, rowid);
+    pTab->pExtData->rowsImpacted += 1;
     return SQLITE_OK;
   }
 

--- a/core/src/rows-impacted.test.c
+++ b/core/src/rows-impacted.test.c
@@ -250,6 +250,31 @@ static void testDeleteThatDoesNotChangeAnything() {
   printf("\t\e[0;32mSuccess\e[0m\n");
 }
 
+static void testDelete() {
+  printf("Delete\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "INSERT INTO foo VALUES (1, 2)", 0, 0, 0);
+
+  rc += sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(db,
+                     "INSERT INTO crsql_changes VALUES ('foo', 1, "
+                     "'__crsql_del', NULL, 1, 2, NULL)",
+                     0, 0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int(pStmt, 0) == 1);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
 static void testCreateThatDoesNotChangeAnything() {
   printf("UpdateThatDoesNotChangeAnything\n");
   int rc = SQLITE_OK;


### PR DESCRIPTION
`__crsql_del` row insertions into `crsql_changes` didn't count towards `crsql_rows_impacted`.

So, I'm not sure if that's the right spot, but it appears to be working as intended.

The early return from the modified function prevented the counter from being incremented. I also added it to the `isPkOnly` branch, even though I'm not sure when that gets triggered.