### PR TITLE
Query performance improvements (xBestIndex fix + no default ordering)

### DIFF
--- a/core/src/changes-vtab-read.c
+++ b/core/src/changes-vtab-read.c
@@ -76,9 +76,7 @@ char *crsql_changesUnionQuery(crsql_TableInfo **tableInfos, int tableInfosLen,
   return sqlite3_mprintf(
       "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id, _rowid_, seq FROM "
       "(%z) "
-      "%s%s ORDER "
-      "BY "
-      "db_vrsn, seq ASC",
+      "%s%s",
       unionsStr, idxStr != 0 && strlen(idxStr) > 0 ? "WHERE " : "",
       idxStr == 0 ? "" : idxStr);
   // %z frees unionsStr https://www.sqlite.org/printf.html#percentz

--- a/core/src/changes-vtab-read.c
+++ b/core/src/changes-vtab-read.c
@@ -76,9 +76,8 @@ char *crsql_changesUnionQuery(crsql_TableInfo **tableInfos, int tableInfosLen,
   return sqlite3_mprintf(
       "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id, _rowid_, seq FROM "
       "(%z) "
-      "%s%s",
-      unionsStr, idxStr != 0 && strlen(idxStr) > 0 ? "WHERE " : "",
-      idxStr == 0 ? "" : idxStr);
+      "%s",
+      unionsStr, idxStr == 0 ? "" : idxStr);
   // %z frees unionsStr https://www.sqlite.org/printf.html#percentz
 }
 

--- a/core/src/changes-vtab-read.test.c
+++ b/core/src/changes-vtab-read.test.c
@@ -61,6 +61,25 @@ static void testChangesUnionQuery() {
   assert(rc == SQLITE_OK);
 
   char *query = crsql_changesUnionQuery(tblInfos, 2, "");
+  assert(
+      strcmp(
+          query,
+          "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id, _rowid_, seq FROM "
+          "(SELECT    "
+          "  'foo' as tbl,      quote(\"a\") as pks,      __crsql_col_name "
+          "as cid,      __crsql_col_version as col_vrsn,      "
+          "__crsql_db_version as db_vrsn,      __crsql_site_id as site_id,  "
+          "    _rowid_,      __crsql_seq as seq   "
+          " FROM \"foo__crsql_clock\" UNION ALL SELECT      'bar' as tbl,      "
+          "quote(\"x\") as pks,      __crsql_col_name as cid,      "
+          "__crsql_col_version as col_vrsn,      __crsql_db_version as "
+          "db_vrsn,      __crsql_site_id as site_id,      _rowid_,      "
+          "__crsql_seq as seq    FROM "
+          "\"bar__crsql_clock\") ") == 0);
+  sqlite3_free(query);
+
+  query = crsql_changesUnionQuery(tblInfos, 2,
+                                  "WHERE site_id IS ? AND db_vrsn > ?");
   printf("Query: X%sX", query);
   assert(
       strcmp(
@@ -76,26 +95,7 @@ static void testChangesUnionQuery() {
           "__crsql_col_version as col_vrsn,      __crsql_db_version as "
           "db_vrsn,      __crsql_site_id as site_id,      _rowid_,      "
           "__crsql_seq as seq    FROM "
-          "\"bar__crsql_clock\")  ORDER BY db_vrsn, seq ASC") == 0);
-  sqlite3_free(query);
-
-  query = crsql_changesUnionQuery(tblInfos, 2, "site_id IS ? AND db_vrsn > ?");
-  assert(
-      strcmp(
-          query,
-          "SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id, _rowid_, seq FROM "
-          "(SELECT    "
-          "  'foo' as tbl,      quote(\"a\") as pks,      __crsql_col_name "
-          "as cid,      __crsql_col_version as col_vrsn,      "
-          "__crsql_db_version as db_vrsn,      __crsql_site_id as site_id,  "
-          "    _rowid_,      __crsql_seq as seq   "
-          " FROM \"foo__crsql_clock\" UNION ALL SELECT      'bar' as tbl,      "
-          "quote(\"x\") as pks,      __crsql_col_name as cid,      "
-          "__crsql_col_version as col_vrsn,      __crsql_db_version as "
-          "db_vrsn,      __crsql_site_id as site_id,      _rowid_,      "
-          "__crsql_seq as seq    FROM "
-          "\"bar__crsql_clock\") WHERE site_id IS ? AND db_vrsn > ? ORDER "
-          "BY db_vrsn, seq ASC") == 0);
+          "\"bar__crsql_clock\") WHERE site_id IS ? AND db_vrsn > ?") == 0);
   sqlite3_free(query);
 
   printf("\t\e[0;32mSuccess\e[0m\n");

--- a/core/src/changes-vtab.c
+++ b/core/src/changes-vtab.c
@@ -454,6 +454,9 @@ static int changesBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
   for (int i = 0; i < pIdxInfo->nConstraint; i++) {
     const struct sqlite3_index_constraint *pConstraint =
         &pIdxInfo->aConstraint[i];
+    if (pConstraint->usable == 0) {
+      continue;
+    }
     switch (pConstraint->iColumn) {
       case CHANGES_SINCE_VTAB_TBL:
         // TODO: stick tbl constraint into pTab?

--- a/core/src/changes-vtab.c
+++ b/core/src/changes-vtab.c
@@ -539,6 +539,10 @@ static int changesBestIndex(sqlite3_vtab *tab, sqlite3_index_info *pIdxInfo) {
   int desc = 0;
   if (pIdxInfo->nOrderBy > 0) {
     sqlite3_str_appendall(pStr, " ORDER BY ");
+  } else {
+    // The user didn't provide an ordering? Tack on a default one that will
+    // retrieve changes in-order
+    sqlite3_str_appendall(pStr, " ORDER BY db_vrsn, seq ASC");
   }
   firstConstraint = 1;
   for (int i = 0; i < pIdxInfo->nOrderBy; i++) {

--- a/core/src/rows-impacted.test.c
+++ b/core/src/rows-impacted.test.c
@@ -356,6 +356,8 @@ void rowsImpactedTestSuite() {
   testManyTxns();
   testUpdateThatDoesNotChangeAnything();
   testDeleteThatDoesNotChangeAnything();
+  testCreateThatDoesNotChangeAnything();
   testValueWin();
   testClockWin();
+  testDelete();
 }

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 source env/bin/activate
-python -m pytest tests -s -k test_crsql_changes_filters
+python -m pytest tests -s
 
 # -k test_sync_prop.py

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 source env/bin/activate
-python -m pytest tests -s
+python -m pytest tests -s -k test_crsql_changes_filters
 
 # -k test_sync_prop.py

--- a/py/correctness/tests/test_crsql_changes_filters.py
+++ b/py/correctness/tests/test_crsql_changes_filters.py
@@ -51,7 +51,7 @@ def run_test(constraint, operation_subset=None, range=range(5)):
         for (opcode, predicate) in operations:
             if operation_subset is None or opcode in operation_subset:
                 tbl_changes = c.execute(
-                    changes_query + " WHERE [{}] {} ?".format(constraint, opcode), (x, )).fetchall()
+                    changes_query + " WHERE [{}] {} ? ORDER BY db_version, seq ASC".format(constraint, opcode), (x, )).fetchall()
                 mnl_changes = list(
                     filter(lambda row: predicate(row[col_mapping[constraint]], x), all_changes))
                 assert (tbl_changes == mnl_changes)

--- a/py/correctness/tests/test_crsql_changes_filters.py
+++ b/py/correctness/tests/test_crsql_changes_filters.py
@@ -19,7 +19,7 @@ def setup_db():
     c.execute("DELETE FROM item WHERE id = 411")
     c.commit()
 
-    return (c, c.execute(changes_query).fetchall())
+    return (c, c.execute(changes_query + " ORDER BY db_version, seq ASC").fetchall())
 
 
 changes_query = "SELECT [table], pk, cid, val, col_version, db_version, site_id, seq FROM crsql_changes"

--- a/py/correctness/tests/test_sync_prop.py
+++ b/py/correctness/tests/test_sync_prop.py
@@ -214,10 +214,10 @@ def sync_from_random_peers(num_peers_to_sync, db, dbs, since_is_rowid):
 def sync_left_to_right(l, r, since, since_is_rowid):
     if since_is_rowid:
         changes = l.execute(
-            "SELECT *, rowid FROM crsql_changes WHERE rowid > ?", (since,))
+            "SELECT *, rowid FROM crsql_changes WHERE rowid > ? ORDER BY db_version, seq ASC", (since,))
     else:
         changes = l.execute(
-            "SELECT * FROM crsql_changes WHERE db_version > ?", (since,))
+            "SELECT * FROM crsql_changes WHERE db_version > ? ORDER BY db_version, seq ASC", (since,))
 
     ret = 0
     for change in changes:


### PR DESCRIPTION
While working with the `crsql_changes` table, I noticed some queries didn't work at all and others were very slow. I'm working with a test table of 1800000 rows, and there are over 3 million crsql_changes row.

I'm using this query in my testing:

```sql
SELECT DISTINCT(db_version) FROM crsql_changes WHERE site_id IS ? AND db_version > ? AND db_version < ?
```

Initial execution time for this query: **8s**

Using `EXPLAIN QUERY PLAN` helped me figure out that no indexes were being used.

This should fix #245 by ignoring "unusable" constraints in `xBestIndex`. According to the docs:
> The `aConstraint[]` array contains information about all constraints that apply to the virtual table. But some of the constraints might not be usable because of the way tables are ordered in a join. The `xBestIndex` method must therefore only consider constraints that have an `aConstraint[].usable` flag which is true.

This first part brought query times down to **2s**, it was finally able to use the indexes instead of doing a full table scan.

Upon further investigation, I figured out the queries being constructed by crsqlite always included `ORDER BY db_version, seq ASC` which caused signifcant slowdown.

For example, here's an explained query it produces internally:

```
sqlite> EXPLAIN QUERY PLAN SELECT tbl, pks, cid, col_vrsn, db_vrsn, site_id, _rowid_, seq FROM (SELECT      'foo' as tbl,      quote("a") as pks,      __crsql_col_name as cid,      __crsql_col_version as col_vrsn,      __crsql_db_version as db_vrsn,      __crsql_site_id as site_id,      _rowid_,      __crsql_seq as seq    FROM "foo__crsql_clock") WHERE site_id IS NULL AND db_vrsn > ? AND db_vrsn < ? ORDER BY db_vrsn, seq AS;

QUERY PLAN
|--SEARCH foo__crsql_clock USING INDEX foo__crsql_clock_dbv_idx (__crsql_db_version>? AND __crsql_db_version<?)
`--USE TEMP B-TREE FOR RIGHT PART OF ORDER BY
```

The `SEARCH` here is great, but the `USE TEMP B-TREE FOR RIGHT PART OF ORDER BY` adds a lot of time in certain cases.

Removing the default `ORDER BY` appended to every `crsql_changes` queries brought the execution time down to **200ms**

Doing this means clients will have to add an ORDER BY if they care about it, it's a bit of a breaking change. However, it gives more low-level control over the produced queries.

Edit: the aforementioned numbers are probably erroneous (definitely not rigorous), but at least it fixes the xBestIndex errors)