### PR TITLE
Fix the build for arm releases

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,9 +73,8 @@ jobs:
 
       - name: Rust Nightly
         run: |
-          rustup default nightly
-          rustup update
-          rustup target add aarch64-apple-darwin
+          rustup toolchain install nightly-2023-06-17
+          rustup target add aarch64-apple-darwin --toolchain nightly-2023-06-17
 
       - name: Build
         run: |
@@ -111,9 +110,8 @@ jobs:
 
       - name: Rust Nightly
         run: |
-          rustup default nightly
-          rustup update
-          rustup target add aarch64-unknown-linux-gnu
+          rustup toolchain install nightly-2023-06-17
+          rustup target add aarch64-unknown-linux-gnu --toolchain nightly-2023-06-17
 
       - name: Build
         run: |


### PR DESCRIPTION
For cases where we are cross-compiling we need to install the target for the current toolchain manually.

Is there not a way to tell Rust to use the same toolchain for all targets in the https://github.com/vlcn-io/cr-sqlite/blob/main/core/rs/core/rust-toolchain.toml file?