### PR TITLE
Binary format for encoding many columns into a single column

### DIFF
--- a/core/rs/bundle/Cargo.lock
+++ b/core/rs/bundle/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +81,8 @@ dependencies = [
 name = "crsql_core"
 version = "0.1.0"
 dependencies = [
+ "bytes",
+ "num-traits",
  "sqlite_nostd",
 ]
 

--- a/core/rs/core/Cargo.lock
+++ b/core/rs/core/Cargo.lock
@@ -37,6 +37,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +72,8 @@ dependencies = [
 name = "crsql_core"
 version = "0.1.0"
 dependencies = [
+ "bytes",
+ "num-traits",
  "sqlite_nostd",
 ]
 

--- a/core/rs/core/Cargo.toml
+++ b/core/rs/core/Cargo.toml
@@ -12,6 +12,8 @@ crate-type = ["rlib"]
 
 [dependencies]
 sqlite_nostd = { path="../sqlite-rs-embedded/sqlite_nostd" }
+bytes = { version = "1.4", default-features = false }
+num-traits = { version = "0.2.15", default-features = false }
 
 [dev-dependencies]
 

--- a/core/rs/core/src/concat_columns.rs
+++ b/core/rs/core/src/concat_columns.rs
@@ -126,7 +126,7 @@ pub enum ColumnValue {
 // TODO: make this a table valued function that can be used to extract a row per packed column?
 // For use from C we'll just do statement prepartion in Rust and pass back the pointer
 // to the sqlite statement.
-fn unpack_columns(data: &[u8]) -> Result<Vec<ColumnValue>, ResultCode> {
+pub fn unpack_columns(data: &[u8]) -> Result<Vec<ColumnValue>, ResultCode> {
     let mut ret = vec![];
     let mut buf = data;
     let num_columns = buf.get_u8();

--- a/core/rs/core/src/concat_columns.rs
+++ b/core/rs/core/src/concat_columns.rs
@@ -1,0 +1,135 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use bytes::{Buf, BufMut};
+use core::slice;
+#[cfg(not(feature = "std"))]
+use num_traits::FromPrimitive;
+use sqlite_nostd as sqlite;
+use sqlite_nostd::{ColumnType, Context, ResultCode, Value};
+
+pub extern "C" fn crsql_concat_columns(
+    ctx: *mut sqlite::context,
+    argc: i32,
+    argv: *mut *mut sqlite::value,
+) {
+    let args = sqlite::args!(argc, argv);
+
+    match concat_columns(args) {
+        Err(code) => {
+            ctx.result_error("Failed to concatenate columns");
+            ctx.result_error_code(code);
+        }
+        Ok(blob) => {
+            ctx.result_blob_owned(blob);
+        }
+    }
+}
+
+fn concat_columns(args: &[*mut sqlite::value]) -> Result<Vec<u8>, ResultCode> {
+    let mut buf = vec![];
+    /*
+     * Format:
+     * [num_columns:u8,...[type:u8, length?:i32, ...bytes:u8[]]]
+     */
+    let len_result: Result<u8, _> = args.len().try_into();
+    if let Ok(len) = len_result {
+        buf.put_u8(len);
+        for value in args {
+            match value.value_type() {
+                ColumnType::Blob => {
+                    buf.put_u8(ColumnType::Blob as u8);
+                    buf.put_i32(value.bytes());
+                    buf.put_slice(value.blob());
+                }
+                ColumnType::Null => {
+                    buf.put_u8(ColumnType::Null as u8);
+                }
+                ColumnType::Float => {
+                    buf.put_u8(ColumnType::Float as u8);
+                    buf.put_f64(value.double());
+                }
+                ColumnType::Integer => {
+                    buf.put_u8(ColumnType::Integer as u8);
+                    buf.put_i64(value.int64());
+                }
+                ColumnType::Text => {
+                    buf.put_u8(ColumnType::Text as u8);
+                    buf.put_i32(value.bytes());
+                    buf.put_slice(value.blob());
+                }
+            }
+        }
+        Ok(buf)
+    } else {
+        Err(ResultCode::ABORT)
+    }
+}
+
+pub enum ColumnValue {
+    Blob(Vec<u8>),
+    Float(f64),
+    Integer(i64),
+    Null,
+    Text(String),
+}
+
+pub fn unpack_columns(data: Vec<u8>) -> Result<Vec<ColumnValue>, ResultCode> {
+    let mut ret = vec![];
+    let mut buf = &data[..];
+    let num_columns = buf.get_u8();
+
+    for _i in 0..num_columns {
+        if !buf.has_remaining() {
+            return Err(ResultCode::ABORT);
+        }
+        let column_type = ColumnType::from_u8(buf.get_u8());
+
+        match column_type {
+            Some(ColumnType::Blob) => {
+                if buf.remaining() < 4 {
+                    return Err(ResultCode::ABORT);
+                }
+                let len = buf.get_i32() as usize;
+                if buf.remaining() < len {
+                    return Err(ResultCode::ABORT);
+                }
+                let bytes = buf.copy_to_bytes(len);
+                ret.push(ColumnValue::Blob(bytes.to_vec()));
+            }
+            Some(ColumnType::Float) => {
+                if buf.remaining() < 8 {
+                    return Err(ResultCode::ABORT);
+                }
+                ret.push(ColumnValue::Float(buf.get_f64()));
+            }
+            Some(ColumnType::Integer) => {
+                if buf.remaining() < 8 {
+                    return Err(ResultCode::ABORT);
+                }
+                ret.push(ColumnValue::Integer(buf.get_i64()));
+            }
+            Some(ColumnType::Null) => {
+                ret.push(ColumnValue::Null);
+            }
+            Some(ColumnType::Text) => {
+                if buf.remaining() < 4 {
+                    return Err(ResultCode::ABORT);
+                }
+                let len = buf.get_i32() as usize;
+                if buf.remaining() < len {
+                    return Err(ResultCode::ABORT);
+                }
+                let bytes = buf.copy_to_bytes(len);
+                ret.push(ColumnValue::Text(unsafe {
+                    String::from_utf8_unchecked(bytes.to_vec())
+                }))
+            }
+            None => return Err(ResultCode::MISUSE),
+        }
+    }
+
+    Ok(ret)
+}

--- a/core/rs/core/src/concat_columns.rs
+++ b/core/rs/core/src/concat_columns.rs
@@ -23,6 +23,7 @@ pub extern "C" fn crsql_concat_columns(
             ctx.result_error_code(code);
         }
         Ok(blob) => {
+            // TODO: pass a destructor so we don't have to copy the blob
             ctx.result_blob_owned(blob);
         }
     }

--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod automigrate;
 mod backfill;
+mod concat_columns;
 mod is_crr;
 mod teardown;
 mod util;
@@ -12,6 +13,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 pub use automigrate::*;
 pub use backfill::*;
+use concat_columns::crsql_concat_columns;
 use core::ffi::{c_int, CStr};
 pub use is_crr::*;
 use sqlite::ResultCode;
@@ -70,6 +72,22 @@ pub extern "C" fn sqlite3_crsqlcore_init(
             sqlite::UTF8,
             None,
             Some(crsql_automigrate),
+            None,
+            None,
+            None,
+        )
+        .unwrap_or(sqlite::ResultCode::ERROR);
+    if rc != ResultCode::OK {
+        return rc as c_int;
+    }
+
+    let rc = db
+        .create_function_v2(
+            "crsql_concat_columns",
+            -1,
+            sqlite::UTF8,
+            None,
+            Some(crsql_concat_columns),
             None,
             None,
             None,

--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -14,6 +14,8 @@ use alloc::vec::Vec;
 pub use automigrate::*;
 pub use backfill::*;
 use concat_columns::crsql_concat_columns;
+pub use concat_columns::unpack_columns;
+pub use concat_columns::ColumnValue;
 use core::ffi::{c_int, CStr};
 pub use is_crr::*;
 use sqlite::ResultCode;

--- a/core/rs/integration-check/Cargo.lock
+++ b/core/rs/integration-check/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
 name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crsql_core"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "num-traits",
+ "sqlite_nostd",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +191,7 @@ version = "0.0.1"
 dependencies = [
  "cargo-valgrind",
  "cc",
+ "crsql_core",
  "integration_utils",
  "sqlite_nostd",
 ]

--- a/core/rs/integration-check/Cargo.toml
+++ b/core/rs/integration-check/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [dependencies]
 sqlite_nostd = { path="../sqlite-rs-embedded/sqlite_nostd", features=["static"] }
+crsql_core = { path="../core" }
 integration_utils = { path="../integration-utils" }
 cargo-valgrind = "2.1.0"
 

--- a/core/rs/integration-check/tests/concat_columns.rs
+++ b/core/rs/integration-check/tests/concat_columns.rs
@@ -24,5 +24,21 @@ fn concat_columns_impl() -> Result<(), ResultCode> {
     select_stmt.step()?;
     let result = select_stmt.column_text(0)?;
     println!("{}", result);
+    assert!(result == "x'0301000000000000000C03000000037374720400000003010203'");
+    // cols:03
+    // type: 01 (integer)
+    // value: 00 00 00 00 00 00 00 0C (12) TODO: encode as variable length integers to save space?
+    // type: 03 (text)
+    // len: 00 00 00 03 (3)
+    // byes: 73 (s) 74 (t) 72 (r)
+    // type: 04 (blob)
+    // len: 00 00 00 03 (3)
+    // bytes: 01 02 03
+    // vs string:
+    // 12|'str'|x'010203'
+    // ^ 18 bytes
+    // vs
+    // 26 bytes
+    // 13 wasted bytes due to not variable length encoding our integers
     Ok(())
 }

--- a/core/rs/integration-check/tests/concat_columns.rs
+++ b/core/rs/integration-check/tests/concat_columns.rs
@@ -26,7 +26,6 @@ fn concat_columns_impl() -> Result<(), ResultCode> {
         .prepare_v2("SELECT quote(crsql_concat_columns(id, x, y)) FROM foo")?;
     select_stmt.step()?;
     let result = select_stmt.column_text(0)?;
-    println!("{}", result);
     assert!(result == "X'03090C0B037374720C03010203'");
     // 03 09 0C 0B 03 73 74 72 0C 03 01 02 03
     // cols: 03
@@ -65,7 +64,6 @@ fn concat_columns_impl() -> Result<(), ResultCode> {
     select_stmt.step()?;
     let result = select_stmt.column_blob(0)?;
     assert!(result.len() == 13);
-    // TODO: pass thru extract function
 
     Ok(())
 }

--- a/core/rs/integration-check/tests/concat_columns.rs
+++ b/core/rs/integration-check/tests/concat_columns.rs
@@ -27,14 +27,21 @@ fn concat_columns_impl() -> Result<(), ResultCode> {
     select_stmt.step()?;
     let result = select_stmt.column_text(0)?;
     println!("{}", result);
-    assert!(result == "X'0301000000000000000C03000000037374720400000003010203'");
+    assert!(result == "X'03090C0B037374720C03010203'");
+    // 03 09 0C 0B 03 73 74 72 0C 03 01 02 03
+    // cols: 03
+    // type & intlen: 09 -> 0b00001001 -> 01 type & 01 intlen
+    // value: 0C -> 12
+    // type & intlen: 0B -> 0b00001011 -> 03 type & 01 intlen
+    // 03 -> len
+    // 73 74 72 -> str
+    // type & intlen: 0C ->  0b00001100 -> 04 type & 01 intlen
+    // len: 03
+    // bytes: 01 02 3
+    // voila, done in 13 bytes! < 18 byte string < 26 byte binary w/o varints
 
-    let select_stmt = db
-        .db
-        .prepare_v2("SELECT crsql_concat_columns(id, x, y) FROM foo")?;
-    select_stmt.step()?;
-    let result = select_stmt.column_blob(0)?;
-
+    // Before variable length encoding:
+    // 03 01 00 00 00 00 00 00 00 0C 03 00 00 00 03 73 74 72 04 00 00 00 03 01 02 03
     // cols:03
     // type: 01 (integer)
     // value: 00 00 00 00 00 00 00 0C (12) TODO: encode as variable length integers to save space?
@@ -46,9 +53,19 @@ fn concat_columns_impl() -> Result<(), ResultCode> {
     // bytes: 01 02 03
     // vs string:
     // 12|'str'|x'010203'
-    // ^ 18 bytes
+    // ^ 18 bytes via string
     // vs
-    // 26 bytes
-    // 13 wasted bytes due to not variable length encoding our integers
+    // 26 bytes via binary
+    // 13 bytes are wasted due to not using variable length encoding for integers
+    // So.. do variable length ints?
+
+    let select_stmt = db
+        .db
+        .prepare_v2("SELECT crsql_concat_columns(id, x, y) FROM foo")?;
+    select_stmt.step()?;
+    let result = select_stmt.column_blob(0)?;
+    assert!(result.len() == 13);
+    // TODO: pass thru extract function
+
     Ok(())
 }

--- a/core/rs/integration-check/tests/concat_columns.rs
+++ b/core/rs/integration-check/tests/concat_columns.rs
@@ -1,0 +1,28 @@
+use sqlite::{Connection, ResultCode};
+use sqlite_nostd as sqlite;
+
+#[test]
+fn concat_columns() {
+    // concat then unpack
+    concat_columns_impl().unwrap();
+}
+
+fn concat_columns_impl() -> Result<(), ResultCode> {
+    let db = integration_utils::opendb()?;
+    db.db.exec_safe("CREATE TABLE foo (id PRIMARY KEY, x, y)")?;
+    let insert_stmt = db.db.prepare_v2("INSERT INTO foo VALUES (?, ?, ?)")?;
+    let blob: [u8; 3] = [1, 2, 3];
+
+    insert_stmt.bind_int(1, 12)?;
+    insert_stmt.bind_text(2, "str", sqlite::Destructor::STATIC)?;
+    insert_stmt.bind_blob(3, &blob, sqlite::Destructor::STATIC)?;
+    insert_stmt.step()?;
+
+    let select_stmt = db
+        .db
+        .prepare_v2("SELECT quote(crsql_concat_columns(id, x, y)) FROM foo")?;
+    select_stmt.step()?;
+    let result = select_stmt.column_text(0)?;
+    println!("{}", result);
+    Ok(())
+}


### PR DESCRIPTION
Format:
```
[num_columns:u8,...[(type(0-3),num_bytes?(3-7)):u8, length?:i32, ...bytes:u8[]]]
```

The byte used for column type also encodes the number of bytes used for the integer.
e.g.: `(type(0-3),num_bytes?(3-7)):u8`
first 3 bits are type
last 5 encode how long the following integer, if there is a following integer, is. 1, 2, 3, ... 8 bytes.

Not packing an integer into the minimal number of bytes required is rather wasteful.
E.g., the number `0` would take 8 bytes rather than 1 byte.

---

We'll use this in three places:

1. In `select` statements, replacing `quote() || ...` with `crsql_concat_columns(...)`
2. In the vtab write path.
3. In the vtab `next` path.

For (2), we'll create a function in Rust that:
1. Takes an enum indicating statement type
2. Takes a pointer to a sqlite_stmt
4. Takes a `const * u8` 
5. Takes an optional table name

We'll `from_raw_parts` the `const *u8` into a `&[u8]` slice, unpack to the relevant columns, bind those columns to the statement as well as bind the table name.

C will then step the statement as normal.

This boundary was chosen since: passing SQLite structs between C and Rust is easy. Trying to pass Rust specific structs (e.g., `Vec<ColumnValue>`) is more difficult.

