### PR TITLE
db_versions don't have to follow the lamport condition, only column v…

### DIFF
--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -494,7 +494,7 @@ static void testLamportCondition() {
   sqlite3_int64 db2v = getDbVersion(db2);
 
   assert(db1v > 0);
-  assert(db1v == db2v);
+  // assert(db1v == db2v);
 
   // now update col c on db2
   // and sync right to left


### PR DESCRIPTION
…ersions

Previously, a db could jump ahead multiple versions after merging with a peer. This is no longer the case. We'll now only increase by 1 after a merge transaction.

col_version is what needs to follow the lamport condition as that is what is used for merging. db_version is only used for fetching deltas and not for merging.