### PR TITLE
update makefile to support ios builds

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -26,6 +26,12 @@ ifdef CONFIG_WINDOWS
 LOADABLE_EXTENSION=dll
 endif
 
+ifdef BUILD_FOR_IOS
+CI_MAYBE_TARGET=aarch64-apple-ios
+rs_build_flags = -Zbuild-std
+sysroot_option = --sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+endif
+
 prefix=./dist
 dbg_prefix=./dbg
 
@@ -137,11 +143,14 @@ $(TARGET_LOADABLE): $(prefix) $(ext_files) $(rs_lib_loadable_cpy)
 	$(CC) -O2 -I./src/ -I./src/sqlite \
 	$(LOADABLE_CFLAGS) \
 	$(C_TARGET) \
+	$(sysroot_option) \
 	$(ext_files) $(rs_lib_loadable_cpy) -o $@
 
 $(TARGET_DBG_LOADABLE): $(dbg_prefix) $(ext_files) $(rs_lib_dbg_loadable_cpy)
 	$(CC) -g -I./src/ -I./src/sqlite \
 	$(LOADABLE_CFLAGS) \
+	$(C_TARGET) \
+	$(sysroot_option) \
 	$(ext_files) $(rs_lib_dbg_loadable_cpy) -o $@
 
 # Build a SQLite CLI that pre-loads cr-sqlite.

--- a/core/Makefile
+++ b/core/Makefile
@@ -26,8 +26,8 @@ ifdef CONFIG_WINDOWS
 LOADABLE_EXTENSION=dll
 endif
 
-ifdef BUILD_FOR_IOS
-CI_MAYBE_TARGET=aarch64-apple-ios
+ifdef IOS_TARGET
+CI_MAYBE_TARGET=$(IOS_TARGET)
 rs_build_flags = -Zbuild-std
 sysroot_option = --sysroot=/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
 endif

--- a/notes.md
+++ b/notes.md
@@ -1,3 +1,25 @@
+# ios
+
+https://mozilla.github.io/firefox-browser-architecture/experiments/2017-09-06-rust-on-ios.html
+cargo install cargo-lipo
+^-- https://github.com/TimNN/cargo-lipo/issues/60
+https://www.reddit.com/r/rust/comments/12w9h4s/how_to_make_armv7appleios_target_by_myself/
+
+```
+cargo build -Zbuild-std --target=aarch64-apple-ios --features static,omit_load_extension
+```
+
+```
+export CI_MAYBE_TARGET=aarch64-apple-ios
+make loadable
+clang: warning: using sysroot for 'MacOSX' but targeting 'iPhone' [-Wincompatible-sysroot]
+```
+
+^- repeat for every ios arch? How to universal binary?
+
+https://stackoverflow.com/questions/823706/compiling-custom-sqlite-for-an-iphone-app
+https://github.com/swiftlyfalling/SQLiteLib
+
 # Prepared read
 
 - parse values and use correct types for binding


### PR DESCRIPTION
so I thought this would be really hard and have been avoiding it for months.

Turns out we just needed to:

1. set the target triple
2. build rust's std from source
3. set the sysroot to the iPhoneOS.sdk

To use:

```
cr-sqlite> cd core
cr-sqlite/core> export BUILD_FOR_IOS=true; make loadable
```

**edit (latest revision):** 
```
cr-sqlite> cd core
cr-sqlite/core> export IOS_TARGET=aarch64-apple-ios; make loadable
```

Now in `dist` you'll have a `crsqlite.dylib` for `ios`

```
ls -ltrh dist
total 37992
-rw-r--r--  1 tantaman  staff   8.3M Jul  7 21:52 sqlite3-extra.c
-rw-r--r--  1 tantaman  staff   5.1M Jul 10 10:59 libcrsql_bundle-loadable.a
-rwxr-xr-x  1 tantaman  staff   848K Jul 10 10:59 crsqlite.dylib
```

# Caveat

This assumes that we can load `dylib` extensions into `sqlite` on iOS. @alanjhughes is investigating this. If we can't then we'll have to build this statically into sqlite which should largely be more of the same changes but for static targets in the Makefile.