### PR TITLE
table valued function to unpack columns

### DIFF
--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -7,6 +7,7 @@ mod compare_values;
 mod is_crr;
 mod pack_columns;
 mod teardown;
+mod unpack_columns_vtab;
 mod util;
 
 use core::{ffi::c_char, slice};
@@ -101,17 +102,24 @@ pub extern "C" fn sqlite3_crsqlcore_init(
         return rc as c_int;
     }
 
-    db.create_function_v2(
-        "crsql_as_table",
-        1,
-        sqlite::UTF8,
-        None,
-        Some(crsql_as_table),
-        None,
-        None,
-        None,
-    )
-    .unwrap_or(sqlite::ResultCode::ERROR) as c_int
+    let rc = db
+        .create_function_v2(
+            "crsql_as_table",
+            1,
+            sqlite::UTF8,
+            None,
+            Some(crsql_as_table),
+            None,
+            None,
+            None,
+        )
+        .unwrap_or(sqlite::ResultCode::ERROR);
+    if rc != ResultCode::OK {
+        return rc as c_int;
+    }
+
+    let rc = unpack_columns_vtab::create_module(db).unwrap_or(sqlite::ResultCode::ERROR);
+    return rc as c_int;
 }
 
 #[no_mangle]

--- a/core/rs/core/src/unpack_columns_vtab.rs
+++ b/core/rs/core/src/unpack_columns_vtab.rs
@@ -1,15 +1,16 @@
 extern crate alloc;
 
 use core::ffi::{c_char, c_int, c_void};
+use core::slice;
 
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
-use sqlite::Connection;
+use sqlite::{Connection, Context, Value};
 use sqlite_nostd as sqlite;
 use sqlite_nostd::ResultCode;
 
-use crate::ColumnValue;
+use crate::{unpack_columns, ColumnValue};
 
 enum Columns {
     CELL = 0,
@@ -44,21 +45,47 @@ extern "C" fn connect(
     ResultCode::OK as c_int
 }
 
-extern "C" fn best_index(_vtab: *mut sqlite::vtab, _index_info: *mut sqlite::index_info) -> c_int {
-    // Assert that package is passed and required via iColumn on pConstraint matches columns::PACKAGE
-    // Set the argvindex on it to 0
+extern "C" fn best_index(_vtab: *mut sqlite::vtab, index_info: *mut sqlite::index_info) -> c_int {
+    // TODO: better bindings to create this slice for the user
+    let constraints = unsafe {
+        slice::from_raw_parts_mut(
+            (*index_info).aConstraint,
+            (*index_info).nConstraint as usize,
+        )
+    };
+    let constraint_usage = unsafe {
+        slice::from_raw_parts_mut(
+            (*index_info).aConstraintUsage,
+            (*index_info).nConstraint as usize,
+        )
+    };
+
+    for (i, constraint) in constraints.iter().enumerate() {
+        if constraint.usable == 0 {
+            continue;
+        }
+        if constraint.iColumn != Columns::PACKAGE as i32 {
+            return ResultCode::MISUSE as c_int;
+        } else {
+            constraint_usage[i].argvIndex = 1;
+            constraint_usage[i].omit = 1;
+        }
+    }
+
     ResultCode::OK as c_int
 }
 
 extern "C" fn disconnect(vtab: *mut sqlite::vtab) -> c_int {
-    sqlite::free(vtab as *mut c_void);
+    unsafe {
+        drop(Box::from_raw(vtab));
+    }
     ResultCode::OK as c_int
 }
 
 #[repr(C)]
 struct Cursor {
     base: sqlite::vtab_cursor,
-    crsr: usize,
+    crsr: i32,
     unpacked: Option<Vec<ColumnValue>>,
 }
 
@@ -68,7 +95,7 @@ extern "C" fn open(_vtab: *mut sqlite::vtab, cursor: *mut *mut sqlite::vtab_curs
             base: sqlite::vtab_cursor {
                 pVtab: core::ptr::null_mut(),
             },
-            crsr: 0,
+            crsr: -1,
             unpacked: None,
         });
         let raw_cursor = Box::into_raw(boxed);
@@ -78,20 +105,38 @@ extern "C" fn open(_vtab: *mut sqlite::vtab, cursor: *mut *mut sqlite::vtab_curs
     ResultCode::OK as c_int
 }
 
-extern "C" fn close(vtab: *mut sqlite::vtab_cursor) -> c_int {
-    sqlite::free(vtab as *mut c_void);
+extern "C" fn close(cursor: *mut sqlite::vtab_cursor) -> c_int {
+    let crsr = cursor.cast::<Cursor>();
+    unsafe {
+        drop(Box::from_raw(crsr));
+    }
     ResultCode::OK as c_int
 }
 
 extern "C" fn filter(
     cursor: *mut sqlite::vtab_cursor,
-    idx_num: c_int,
-    idx_str: *const c_char,
+    _idx_num: c_int,
+    _idx_str: *const c_char,
     argc: c_int,
     argv: *mut *mut sqlite::value,
 ) -> c_int {
     // pull out package arg as set up by xBestIndex (should always be argv0)
     // stick into cursor
+    let args = sqlite::args!(argc, argv);
+    if args.len() != 1 {
+        return ResultCode::MISUSE as c_int;
+    }
+
+    let crsr = cursor.cast::<Cursor>();
+    unsafe {
+        if let Ok(cols) = unpack_columns(args[0].blob()) {
+            (*crsr).unpacked = Some(cols);
+            (*crsr).crsr = -1;
+        } else {
+            return ResultCode::ERROR as c_int;
+        }
+    }
+
     ResultCode::OK as c_int
 }
 
@@ -99,27 +144,74 @@ extern "C" fn next(cursor: *mut sqlite::vtab_cursor) -> c_int {
     // go so long as crsr < unpacked.len
     // if crsr == unpacked.len continue
     // else, return done
+    let crsr = cursor.cast::<Cursor>();
+    unsafe {
+        (*crsr).crsr += 1;
+    }
     ResultCode::OK as c_int
 }
 
 extern "C" fn eof(cursor: *mut sqlite::vtab_cursor) -> c_int {
     // crsr >= unpacked.len
-    ResultCode::OK as c_int
+    let crsr = cursor.cast::<Cursor>();
+    unsafe {
+        match &(*crsr).unpacked {
+            Some(cols) => {
+                if (*crsr).crsr >= cols.len() as i32 {
+                    1
+                } else {
+                    0
+                }
+            }
+            None => 1,
+        }
+    }
 }
 
 extern "C" fn column(
     cursor: *mut sqlite::vtab_cursor,
-    context: *mut sqlite::context,
+    ctx: *mut sqlite::context,
     col_num: c_int,
 ) -> c_int {
-    // columns enum to pull what was selected
-    // they can only select cell.
-    // allow selecting the hidden col? We'd need to keep the original
-    ResultCode::OK as c_int
+    let crsr = cursor.cast::<Cursor>();
+    if col_num == Columns::CELL as i32 {
+        unsafe {
+            if let Some(cols) = &(*crsr).unpacked {
+                if (*crsr).crsr < 0 {
+                    ResultCode::ABORT as c_int
+                } else {
+                    let col_value = &cols[(*crsr).crsr as usize];
+                    match col_value {
+                        ColumnValue::Blob(b) => {
+                            ctx.result_blob_static(b);
+                        }
+                        ColumnValue::Float(f) => {
+                            ctx.result_double(*f);
+                        }
+                        ColumnValue::Integer(i) => {
+                            ctx.result_int64(*i);
+                        }
+                        ColumnValue::Null => {
+                            ctx.result_null();
+                        }
+                        ColumnValue::Text(t) => {
+                            ctx.result_text_static(t);
+                        }
+                    }
+                    ResultCode::OK as c_int
+                }
+            } else {
+                ResultCode::ABORT as c_int
+            }
+        }
+    } else {
+        ResultCode::MISUSE as c_int
+    }
 }
 
 extern "C" fn rowid(cursor: *mut sqlite::vtab_cursor, row_id: *mut sqlite::int64) -> c_int {
-    // rowid is just crsr
+    let crsr = cursor.cast::<Cursor>();
+    unsafe { *row_id = (*crsr).crsr as i64 }
     ResultCode::OK as c_int
 }
 
@@ -127,7 +219,6 @@ extern "C" fn rowid(cursor: *mut sqlite::vtab_cursor, row_id: *mut sqlite::int64
  * CREATE TABLE [x] (cell, package HIDDEN);
  * SELECT cell FROM crsql_unpack_columns WHERE package = ___;
  */
-
 pub fn create_module(db: *mut sqlite::sqlite3) -> Result<ResultCode, ResultCode> {
     let module = Box::new(sqlite_nostd::module {
         iVersion: 0,

--- a/core/rs/core/src/unpack_columns_vtab.rs
+++ b/core/rs/core/src/unpack_columns_vtab.rs
@@ -48,7 +48,7 @@ extern "C" fn connect(
 }
 
 extern "C" fn disconnect(vtab: *mut sqlite::vtab) -> c_int {
-    sqlite::free(vtab);
+    sqlite::free(vtab as *mut c_void);
     // unsafe {
     // drop(Box::from_raw(vtab));
     // }
@@ -117,7 +117,7 @@ extern "C" fn open(_vtab: *mut sqlite::vtab, cursor: *mut *mut sqlite::vtab_curs
 
 extern "C" fn close(cursor: *mut sqlite::vtab_cursor) -> c_int {
     // let crsr = cursor.cast::<Cursor>();
-    sqlite::free(cursor);
+    sqlite::free(cursor as *mut c_void);
     // unsafe {
     //     drop(Box::from_raw(crsr));
     // }

--- a/core/rs/core/src/unpack_columns_vtab.rs
+++ b/core/rs/core/src/unpack_columns_vtab.rs
@@ -1,0 +1,103 @@
+extern crate alloc;
+
+use core::ffi::{c_char, c_int, c_void};
+
+use alloc::boxed::Box;
+use sqlite::Connection;
+use sqlite_nostd as sqlite;
+use sqlite_nostd::ResultCode;
+
+extern "C" fn connect(
+    db: *mut sqlite::sqlite3,
+    aux: *mut c_void,
+    argc: c_int,
+    argv: *const *const c_char,
+    vtab: *mut *mut sqlite::vtab,
+    err: *mut *mut c_char,
+) -> c_int {
+    ResultCode::OK as c_int
+}
+
+extern "C" fn best_index(vtab: *mut sqlite::vtab, index_info: *mut sqlite::index_info) -> c_int {
+    ResultCode::OK as c_int
+}
+
+extern "C" fn disconnect(vtab: *mut sqlite::vtab) -> c_int {
+    sqlite::free(vtab as *mut c_void);
+    ResultCode::OK as c_int
+}
+
+extern "C" fn open(vtab: *mut sqlite::vtab, cursor: *mut *mut sqlite::vtab_cursor) -> c_int {
+    ResultCode::OK as c_int
+}
+
+extern "C" fn close(vtab: *mut sqlite::vtab_cursor) -> c_int {
+    ResultCode::OK as c_int
+}
+
+extern "C" fn filter(
+    cursor: *mut sqlite::vtab_cursor,
+    idx_num: c_int,
+    idx_str: *const c_char,
+    argc: c_int,
+    argv: *mut *mut sqlite::value,
+) -> c_int {
+    ResultCode::OK as c_int
+}
+
+extern "C" fn next(cursor: *mut sqlite::vtab_cursor) -> c_int {
+    ResultCode::OK as c_int
+}
+
+extern "C" fn eof(cursor: *mut sqlite::vtab_cursor) -> c_int {
+    ResultCode::OK as c_int
+}
+
+extern "C" fn column(
+    cursor: *mut sqlite::vtab_cursor,
+    context: *mut sqlite::context,
+    col_num: c_int,
+) -> c_int {
+    ResultCode::OK as c_int
+}
+
+extern "C" fn rowid(cursor: *mut sqlite::vtab_cursor, row_id: *mut sqlite::int64) -> c_int {
+    ResultCode::OK as c_int
+}
+
+/**
+ * CREATE TABLE [x] (cell, package HIDDEN);
+ * SELECT cell FROM crsql_unpack_columns WHERE package = ___;
+ */
+
+pub fn create_module(db: *mut sqlite::sqlite3) -> Result<ResultCode, ResultCode> {
+    let module = Box::new(sqlite_nostd::module {
+        iVersion: 0,
+        xCreate: None,
+        xConnect: Some(connect),
+        xBestIndex: Some(best_index),
+        xDisconnect: Some(disconnect),
+        xDestroy: None,
+        xOpen: Some(open),
+        xClose: Some(close),
+        xFilter: Some(filter),
+        xNext: Some(next),
+        xEof: Some(eof),
+        xColumn: Some(column),
+        xRowid: Some(rowid),
+        xUpdate: None,
+        xBegin: None,
+        xSync: None,
+        xCommit: None,
+        xRollback: None,
+        xFindFunction: None,
+        xRename: None,
+        xSavepoint: None,
+        xRelease: None,
+        xRollbackTo: None,
+        xShadowName: None,
+    });
+    db.create_module_v2("crsql_unpack_columns", Box::into_raw(module), None, None)?;
+
+    Ok(ResultCode::OK)
+}

--- a/core/rs/core/src/unpack_columns_vtab.rs
+++ b/core/rs/core/src/unpack_columns_vtab.rs
@@ -63,8 +63,6 @@ struct Cursor {
 }
 
 extern "C" fn open(_vtab: *mut sqlite::vtab, cursor: *mut *mut sqlite::vtab_cursor) -> c_int {
-    // allocate our cursor object
-    // e.g., https://www.sqlite.org/src/artifact?ci=trunk&filename=ext/misc/series.c
     unsafe {
         let boxed = Box::new(Cursor {
             base: sqlite::vtab_cursor {
@@ -81,6 +79,7 @@ extern "C" fn open(_vtab: *mut sqlite::vtab, cursor: *mut *mut sqlite::vtab_curs
 }
 
 extern "C" fn close(vtab: *mut sqlite::vtab_cursor) -> c_int {
+    sqlite::free(vtab as *mut c_void);
     ResultCode::OK as c_int
 }
 
@@ -91,15 +90,20 @@ extern "C" fn filter(
     argc: c_int,
     argv: *mut *mut sqlite::value,
 ) -> c_int {
-    // pull out package arg.
+    // pull out package arg as set up by xBestIndex (should always be argv0)
+    // stick into cursor
     ResultCode::OK as c_int
 }
 
 extern "C" fn next(cursor: *mut sqlite::vtab_cursor) -> c_int {
+    // go so long as crsr < unpacked.len
+    // if crsr == unpacked.len continue
+    // else, return done
     ResultCode::OK as c_int
 }
 
 extern "C" fn eof(cursor: *mut sqlite::vtab_cursor) -> c_int {
+    // crsr >= unpacked.len
     ResultCode::OK as c_int
 }
 
@@ -108,10 +112,14 @@ extern "C" fn column(
     context: *mut sqlite::context,
     col_num: c_int,
 ) -> c_int {
+    // columns enum to pull what was selected
+    // they can only select cell.
+    // allow selecting the hidden col? We'd need to keep the original
     ResultCode::OK as c_int
 }
 
 extern "C" fn rowid(cursor: *mut sqlite::vtab_cursor, row_id: *mut sqlite::int64) -> c_int {
+    // rowid is just crsr
     ResultCode::OK as c_int
 }
 


### PR DESCRIPTION
```sql
sqlite> create table foo (a, b, c);
sqlite> insert into foo values (1,2,3);
sqlite> select cell from crsql_unpack_columns where package = (select crsql_pack_columns(a,b,c) from foo);
1
2
3
```

The virtual table rust bindings are rather low level at the moment. Need to use them a bit more to understand the best ergonomics that also minimize copying across the ffi boudnary.