### PR TITLE
safe bigints for better-sqlite3 changeset pulling

### DIFF
--- a/js/packages/direct-connect-nodejs/src/private/DB.ts
+++ b/js/packages/direct-connect-nodejs/src/private/DB.ts
@@ -50,6 +50,7 @@ export default class DB {
       `SELECT "table", "pk", "cid", "val", "col_version", "db_version" FROM crsql_changes WHERE db_version > ? AND site_id IS NOT ?`
     );
     this.#pullChangesetStmt.raw(true);
+    this.#pullChangesetStmt.safeIntegers(true);
     const applyChangesetStmt = this.db.prepare(
       `INSERT INTO crsql_changes ("table", "pk", "cid", "val", "col_version", "db_version", "site_id") VALUES (?, ?, ?, ?, ?, ?, ?)`
     );


### PR DESCRIPTION
better-sqlite3 is garbage at handling bigints. It truncates integers without warning if they are > 2^53. You can change the behavior to treat all integers as bigints but this is problematic too since not all ints are bigints.

Anyway... enable this behavior for the `changes` statements where all numbers can be 2^64.