### PR TITLE
Always mark a sentinel on row create, record delete on pk modification, record create on pk modification

### DIFF
--- a/core/rs/core/src/alter.rs
+++ b/core/rs/core/src/alter.rs
@@ -1,0 +1,137 @@
+// Not yet fully migrated from `crsqlite.c`
+
+use core::ffi::{c_char, c_int, CStr};
+
+use alloc::format;
+use alloc::string::String;
+use core::slice;
+#[cfg(not(feature = "std"))]
+use num_traits::FromPrimitive;
+use sqlite_nostd as sqlite;
+use sqlite_nostd::{sqlite3, Connection, ResultCode};
+
+use crate::c::{
+    crsql_ExtData, crsql_ensureTableInfosAreUpToDate, crsql_findTableInfo, crsql_getDbVersion,
+};
+
+#[no_mangle]
+pub unsafe extern "C" fn crsql_compact_post_alter(
+    db: *mut sqlite3,
+    tbl_name: *const c_char,
+    ext_data: *mut crsql_ExtData,
+    errmsg: *mut *mut c_char,
+) -> c_int {
+    match compact_post_alter(db, tbl_name, ext_data, errmsg) {
+        Ok(rc) | Err(rc) => rc as c_int,
+    }
+}
+
+unsafe fn compact_post_alter(
+    db: *mut sqlite3,
+    tbl_name: *const c_char,
+    ext_data: *mut crsql_ExtData,
+    errmsg: *mut *mut c_char,
+) -> Result<ResultCode, ResultCode> {
+    let tbl_name_str = CStr::from_ptr(tbl_name).to_str()?;
+    let c_rc = crsql_getDbVersion(db, ext_data, errmsg);
+    if c_rc != ResultCode::OK as c_int {
+        if let Some(rc) = ResultCode::from_i32(c_rc) {
+            return Err(rc);
+        }
+        return Err(ResultCode::ERROR);
+    }
+    let current_db_version = (*ext_data).dbVersion;
+
+    // If primary key columns change
+    // We need to drop, re-create and backfill
+    // the clock table.
+    // A change in pk columns means a change in all identities
+    // of all rows.
+    // We can determine this by comparing pks on clock table vs
+    // pks on source table
+    let stmt = db.prepare_v2(&format!(
+        "SELECT count(name) FROM (
+        SELECT name FROM pragma_table_info('{table_name}')
+          WHERE pk > 0 AND name NOT IN
+            (SELECT name FROM pragma_table_info('{table_name}__crsql_clock') WHERE pk > 0)
+          UNION SELECT name FROM pragma_table_info('{table_name}__crsql_clock') WHERE pk > 0 AND name NOT IN 
+            (SELECT name FROM pragma_table_info('{table_name}') WHERE pk > 0) AND name != '__crsql_col_name'
+        );",
+        table_name = crate::util::escape_ident_as_value(tbl_name_str),
+    ))?;
+    stmt.step()?;
+
+    let pk_diff = stmt.column_int(0)?;
+    // immediately drop stmt, otherwise clock table is considered locked.
+    drop(stmt);
+
+    if pk_diff > 0 {
+        // drop the clock table so we can re-create it
+        db.exec_safe(&format!(
+            "DROP TABLE \"{table_name}__crsql_clock\"",
+            table_name = crate::util::escape_ident(tbl_name_str),
+        ))?;
+    } else {
+        // clock table is still relevant but needs compacting
+        // in case columns were removed during the migration
+
+        // First delete entries that no longer have a column
+        let sql = format!(
+            "DELETE FROM \"{tbl_name_ident}__crsql_clock\" WHERE \"__crsql_col_name\" NOT IN (
+              SELECT name FROM pragma_table_info('{tbl_name_val}') UNION SELECT '{del_sentinel}' UNION SELECT '{pk_sentinel}'
+            )",
+            tbl_name_ident = crate::util::escape_ident(tbl_name_str),
+            tbl_name_val = crate::util::escape_ident_as_value(tbl_name_str),
+            del_sentinel = crate::c::DELETE_SENTINEL,
+            pk_sentinel = crate::c::INSERT_SENTINEL
+        );
+        db.exec_safe(&sql)?;
+
+        // Next delete entries that no longer have a row
+        let mut sql = String::from(
+            format!(
+              "DELETE FROM \"{tbl_name}__crsql_clock\" WHERE __crsql_col_name != '__crsql_del' AND NOT EXISTS (SELECT 1 FROM \"{tbl_name}\" WHERE ",
+              tbl_name = crate::util::escape_ident(tbl_name_str),
+            ),
+        );
+        let c_rc = crsql_ensureTableInfosAreUpToDate(db, ext_data, errmsg);
+        if c_rc != ResultCode::OK as c_int {
+            if let Some(rc) = ResultCode::from_i32(c_rc) {
+                return Err(rc);
+            }
+            return Err(ResultCode::ERROR);
+        }
+        let table_info = crsql_findTableInfo(
+            (*ext_data).zpTableInfos,
+            (*ext_data).tableInfosLen,
+            tbl_name,
+        );
+        if table_info.is_null() {
+            return Err(ResultCode::ERROR);
+        }
+
+        // for each pk col, append \"%w\".\"%w\" = \"%w__crsql_clock\".\"%w\"
+        // to the where clause then close the statement.
+        let pk_cols = sqlite::args!((*table_info).pksLen, (*table_info).pks);
+        for (i, col) in pk_cols.iter().enumerate() {
+            if i > 0 {
+                sql.push_str(" AND ");
+            }
+            let col_name_str = CStr::from_ptr((*col).name).to_str()?;
+            sql.push_str(&format!(
+                "\"{tbl_name}\".\"{col_name}\" = \"{tbl_name}__crsql_clock\".\"{col_name}\"",
+                tbl_name = tbl_name_str,
+                col_name = col_name_str,
+            ));
+        }
+        sql.push_str(" LIMIT 1)");
+        db.exec_safe(&sql)?;
+    }
+
+    let stmt = db.prepare_v2(
+        "INSERT OR REPLACE INTO crsql_master (key, value) VALUES ('pre_compact_dbversion', ?)",
+    )?;
+    stmt.bind_int64(1, current_db_version)?;
+    stmt.step()?;
+    Ok(ResultCode::OK)
+}

--- a/core/rs/core/src/alter.rs
+++ b/core/rs/core/src/alter.rs
@@ -42,7 +42,7 @@ unsafe fn compact_post_alter(
     }
     let current_db_version = (*ext_data).dbVersion;
 
-    // If primary key columns change
+    // If primary key columns change (in the schema)
     // We need to drop, re-create and backfill
     // the clock table.
     // A change in pk columns means a change in all identities

--- a/core/rs/core/src/c.rs
+++ b/core/rs/core/src/c.rs
@@ -117,6 +117,11 @@ extern "C" {
         len: ::core::ffi::c_int,
         tblName: *const ::core::ffi::c_char,
     ) -> ::core::ffi::c_int;
+    pub fn crsql_findTableInfo(
+        tblInfos: *mut *mut crsql_TableInfo,
+        len: c_int,
+        tblName: *const c_char,
+    ) -> *mut crsql_TableInfo;
     pub fn crsql_ensureTableInfosAreUpToDate(
         db: *mut sqlite::sqlite3,
         pExtData: *mut crsql_ExtData,
@@ -126,6 +131,11 @@ extern "C" {
         colName: *const c_char,
         colInfos: *mut crsql_ColumnInfo,
         colInfosLen: c_int,
+    ) -> c_int;
+    pub fn crsql_getDbVersion(
+        db: *mut sqlite::sqlite3,
+        ext_data: *mut crsql_ExtData,
+        err_msg: *mut *mut c_char,
     ) -> c_int;
 }
 

--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(test), no_std)]
 #![feature(vec_into_raw_parts)]
 
+mod alter;
 mod automigrate;
 mod backfill;
 mod bootstrap;

--- a/core/rs/core/src/teardown.rs
+++ b/core/rs/core/src/teardown.rs
@@ -30,6 +30,20 @@ pub fn remove_crr_triggers_if_exist(
         table = escaped_table
     ))?;
 
+    // get all columns of table
+    // iterate pk cols
+    // drop triggers against those pk cols
+    let stmt = db.prepare_v2("SELECT name FROM pragma_table_info(?) WHERE pk > 0")?;
+    stmt.bind_text(1, table, sqlite::Destructor::STATIC)?;
+    while stmt.step()? == ResultCode::ROW {
+        let col_name = stmt.column_text(0)?;
+        db.exec_safe(&format!(
+            "DROP TRIGGER IF EXISTS \"{tbl_name}_{col_name}__crsql_utrig\"",
+            tbl_name = crate::util::escape_ident(table),
+            col_name = crate::util::escape_ident(col_name),
+        ))?;
+    }
+
     db.exec_safe(&format!(
         "DROP TRIGGER IF EXISTS \"{table}__crsql_dtrig\"",
         table = escaped_table

--- a/core/rs/core/src/triggers.rs
+++ b/core/rs/core/src/triggers.rs
@@ -153,7 +153,7 @@ fn create_update_trigger(
     for col in pk_columns {
         let col_name = unsafe { CStr::from_ptr(col.name).to_str()? };
         db.exec_safe(&format!(
-            "CREATE TRIGGER IF NOT EXISTS \"{tbl_name}_{col_name}_crsql_utrig\"
+            "CREATE TRIGGER IF NOT EXISTS \"{tbl_name}_{col_name}__crsql_utrig\"
           AFTER UPDATE OF \"{col_name}\" ON \"{tbl_name}\"
           WHEN crsql_internal_sync_bit = 0 AND NEW.\"{col_name}\" IS NOT OLD.\"{col_name}\"
           BEGIN

--- a/core/rs/core/src/triggers.rs
+++ b/core/rs/core/src/triggers.rs
@@ -154,7 +154,7 @@ fn create_update_trigger(
         db.exec_safe(&format!(
             "CREATE TRIGGER IF NOT EXISTS \"{tbl_name}_{col_name}__crsql_utrig\"
           AFTER UPDATE OF \"{col_name}\" ON \"{tbl_name}\"
-          WHEN crsql_internal_sync_bit = 0 AND NEW.\"{col_name}\" IS NOT OLD.\"{col_name}\"
+          WHEN crsql_internal_sync_bit() = 0 AND NEW.\"{col_name}\" IS NOT OLD.\"{col_name}\"
           BEGIN
             INSERT INTO \"{table_name}__crsql_clock\" (
               {pk_list},

--- a/core/rs/core/src/triggers.rs
+++ b/core/rs/core/src/triggers.rs
@@ -5,13 +5,12 @@ use alloc::vec;
 use sqlite::Connection;
 
 use core::{
-    any,
     ffi::{c_char, c_int, CStr},
     slice,
     str::Utf8Error,
 };
 
-use crate::c::{crsql_ColumnInfo, crsql_TableInfo};
+use crate::c::crsql_TableInfo;
 use sqlite::{sqlite3, ResultCode};
 use sqlite_nostd as sqlite;
 

--- a/core/rs/core/src/triggers.rs
+++ b/core/rs/core/src/triggers.rs
@@ -70,14 +70,15 @@ fn insert_trigger_body(
     let non_pk_columns =
         unsafe { slice::from_raw_parts((*table_info).nonPks, (*table_info).nonPksLen as usize) };
     let mut trigger_components = vec![];
-    if non_pk_columns.len() == 0 {
-        trigger_components.push(format_insert_trigger_component(
-            table_name,
-            &pk_list,
-            &pk_new_list,
-            crate::c::INSERT_SENTINEL,
-        ))
-    }
+
+    // Insert a record of it existing in all cases
+    trigger_components.push(format_insert_trigger_component(
+        table_name,
+        &pk_list,
+        &pk_new_list,
+        crate::c::INSERT_SENTINEL,
+    ));
+
     for col in non_pk_columns {
         let col_name = unsafe { CStr::from_ptr(col.name).to_str()? };
         trigger_components.push(format_insert_trigger_component(

--- a/core/rs/core/src/util.rs
+++ b/core/rs/core/src/util.rs
@@ -61,7 +61,7 @@ pub fn pk_where_list(
         let name = unsafe { CStr::from_ptr(c.name) };
         result.push(if let Some(prefix) = rhs_prefix {
             format!(
-                "\"{col_name}\" = {prefix}\"{col_name}\"",
+                "\"{col_name}\" IS {prefix}\"{col_name}\"",
                 prefix = prefix,
                 col_name = crate::util::escape_ident(name.to_str()?)
             )
@@ -80,7 +80,7 @@ pub fn where_list(columns: &[crsql_ColumnInfo]) -> Result<String, Utf8Error> {
     for c in columns {
         let name = unsafe { CStr::from_ptr(c.name) };
         result.push(format!(
-            "\"{col_name}\" = ?",
+            "\"{col_name}\" IS ?",
             col_name = crate::util::escape_ident(name.to_str()?)
         ));
     }

--- a/core/rs/integration-check/tests/backfill.rs
+++ b/core/rs/integration-check/tests/backfill.rs
@@ -55,34 +55,52 @@ fn new_nonempty_table_impl(apply_twice: bool) -> Result<(), ResultCode> {
 
     let mut cnt = 0;
     while stmt.step()? == ResultCode::ROW {
+        if cnt % 2 == 0 {
+            assert_eq!(
+                stmt.column_int64(0)?,
+                ((cnt + 1) as f64 / 2.0).ceil() as i64
+            ); // pk
+            assert_eq!(stmt.column_text(1)?, "__crsql_pko"); // col name
+            assert_eq!(stmt.column_int64(2)?, 1); // col version
+            assert_eq!(stmt.column_int64(3)?, 1); // db version
+        } else {
+            assert_eq!(stmt.column_int64(0)?, (cnt + 1) / 2); // pk
+            assert_eq!(stmt.column_text(1)?, "name"); // col name
+            assert_eq!(stmt.column_int64(2)?, 1); // col version
+            assert_eq!(stmt.column_int64(3)?, 1); // db version
+        }
         cnt = cnt + 1;
-        assert_eq!(stmt.column_int64(0)?, cnt); // pk
-        assert_eq!(stmt.column_text(1)?, "name"); // col name
-        assert_eq!(stmt.column_int64(2)?, 1); // col version
-        assert_eq!(stmt.column_int64(3)?, 1); // db version
     }
-    assert_eq!(cnt, 2);
+    assert_eq!(cnt, 4);
 
     // select from crsql_changes too
     let stmt = db.db.prepare_v2(
         "SELECT [table], [pk], [cid], [val], [col_version], [db_version] FROM crsql_changes;",
     )?;
     let mut cnt = 0;
-    while stmt.step()? == ResultCode::ROW {
-        cnt = cnt + 1;
-        if cnt == 1 {
+    while stmt.step().unwrap() == ResultCode::ROW {
+        if cnt < 2 {
             assert_eq!(stmt.column_blob(1)?, [1, 9, 1]); // pk
-            assert_eq!(stmt.column_text(3)?, "one"); // col value
+            if cnt == 1 {
+                assert_eq!(stmt.column_text(3)?, "one"); // col value
+            }
         } else {
             assert_eq!(stmt.column_blob(1)?, [1, 9, 2]); // pk
-            assert_eq!(stmt.column_text(3)?, "two"); // col value
+            if cnt == 3 {
+                assert_eq!(stmt.column_text(3)?, "two"); // col value
+            }
         }
         assert_eq!(stmt.column_text(0)?, "foo"); // table name
-        assert_eq!(stmt.column_text(2)?, "name"); // col name
+        if cnt % 2 == 0 {
+            assert_eq!(stmt.column_text(2)?, "__crsql_pko"); // col name
+        } else {
+            assert_eq!(stmt.column_text(2)?, "name"); // col name
+        }
         assert_eq!(stmt.column_int64(4)?, 1); // col version
         assert_eq!(stmt.column_int64(5)?, 1); // db version
+        cnt = cnt + 1;
     }
-    assert_eq!(cnt, 2);
+    assert_eq!(cnt, 4);
     Ok(())
 }
 

--- a/core/src/changes-vtab-read.test.c
+++ b/core/src/changes-vtab-read.test.c
@@ -106,7 +106,7 @@ static void testRowPatchDataQuery() {
   const char *cid = "b";
   char *pks = "1";
   char *q = crsql_row_patch_data_query(tblInfo, cid);
-  assert(strcmp(q, "SELECT \"b\" FROM \"foo\" WHERE \"a\" = ?") == 0);
+  assert(strcmp(q, "SELECT \"b\" FROM \"foo\" WHERE \"a\" IS ?") == 0);
   sqlite3_free(q);
 
   printf("\t\e[0;32mSuccess\e[0m\n");

--- a/core/src/changes-vtab-rowid.test.c
+++ b/core/src/changes-vtab-rowid.test.c
@@ -68,6 +68,10 @@ static void testRowidsForReads() {
   assert(sqlite3_column_int64(pStmt, 0) == 1);
   assert(sqlite3_step(pStmt) == SQLITE_ROW);
   assert(sqlite3_column_int64(pStmt, 0) == 2);
+  assert(sqlite3_step(pStmt) == SQLITE_ROW);
+  assert(sqlite3_column_int64(pStmt, 0) == 3);
+  assert(sqlite3_step(pStmt) == SQLITE_ROW);
+  assert(sqlite3_column_int64(pStmt, 0) == 4);
   sqlite3_finalize(pStmt);
 
   rc = sqlite3_exec(db, "CREATE TABLE bar (a primary key, b)", 0, 0, 0);
@@ -88,13 +92,25 @@ static void testRowidsForReads() {
   sqlite3_step(pStmt);
   assert(sqlite3_column_int64(pStmt, 0) == 2);
   sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 3);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 4);
+  sqlite3_step(pStmt);
   assert(sqlite3_column_int64(pStmt, 0) == 1 * ROWID_SLAB_SIZE + 1);
   sqlite3_step(pStmt);
   assert(sqlite3_column_int64(pStmt, 0) == 1 * ROWID_SLAB_SIZE + 2);
   sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 1 * ROWID_SLAB_SIZE + 3);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 1 * ROWID_SLAB_SIZE + 4);
+  sqlite3_step(pStmt);
   assert(sqlite3_column_int64(pStmt, 0) == 2 * ROWID_SLAB_SIZE + 1);
   sqlite3_step(pStmt);
   assert(sqlite3_column_int64(pStmt, 0) == 2 * ROWID_SLAB_SIZE + 2);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 2 * ROWID_SLAB_SIZE + 3);
+  sqlite3_step(pStmt);
+  assert(sqlite3_column_int64(pStmt, 0) == 2 * ROWID_SLAB_SIZE + 4);
   sqlite3_finalize(pStmt);
 
   crsql_close(db);

--- a/core/src/changes-vtab.test.c
+++ b/core/src/changes-vtab.test.c
@@ -72,7 +72,8 @@ static void testFilters() {
   assert(rc == SQLITE_OK);
 
   printf("no filters\n");
-  assertCount(db, "SELECT count(*) FROM crsql_changes", 3);
+  // 6 - 1 for each row creation, 1 for each b
+  assertCount(db, "SELECT count(*) FROM crsql_changes", 6);
 
   // now test:
   // 1. site_id comparison
@@ -80,7 +81,7 @@ static void testFilters() {
 
   printf("is null\n");
   assertCount(db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NULL",
-              3);
+              6);
 
   printf("is not null\n");
   assertCount(
@@ -106,7 +107,7 @@ static void testFilters() {
   assertCount(
       db,
       "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT crsql_siteid()",
-      3);
+      6);
 
   // compare on db_version _and_ site_id
 
@@ -115,13 +116,13 @@ static void testFilters() {
   assertCount(db,
               "SELECT count(*) FROM crsql_changes WHERE db_version >= 1 AND "
               "db_version < 2",
-              1);
+              2);
 
   printf("OR condition\n");
   assertCount(db,
               "SELECT count(*) FROM crsql_changes WHERE db_version > 2 OR "
               "site_id IS NULL",
-              3);
+              6);
 
   // compare on pks, table name, other not perfectly supported columns
 

--- a/core/src/consts.h
+++ b/core/src/consts.h
@@ -8,9 +8,6 @@
 
 #define __CRSQL_CLOCK_LEN 13
 
-#define DELETE_CID_SENTINEL "__crsql_del"
-#define PKS_ONLY_CID_SENTINEL "__crsql_pko"
-
 #define CRR_SPACE 0
 #define USER_SPACE 1
 

--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -620,29 +620,10 @@ static void testPullingOnlyLocalChanges() {
   assert(rc == SQLITE_ROW);
 
   int count = sqlite3_column_int(pStmt, 0);
-  // we created 2 local changes, we should get 2 changes back
+  // we created 2 local changes, we should get 2 changes back. Well 4 really
+  // since row creation is an event.
   printf("count: %d\n", count);
-  assert(count == 2);
-  sqlite3_finalize(pStmt);
-
-  sqlite3_prepare_v2(
-      db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT NULL", -1,
-      &pStmt, 0);
-  rc = sqlite3_step(pStmt);
-  assert(rc == SQLITE_ROW);
-  count = sqlite3_column_int(pStmt, 0);
-  // we asked for changes that were not local
-  assert(count == 0);
-  sqlite3_finalize(pStmt);
-
-  sqlite3_prepare_v2(db,
-                     "SELECT count(*) FROM crsql_changes WHERE site_id IS NULL",
-                     -1, &pStmt, 0);
-  rc = sqlite3_step(pStmt);
-  assert(rc == SQLITE_ROW);
-  count = sqlite3_column_int(pStmt, 0);
-  // we asked for changes that were not local
-  assert(count == 2);
+  assert(count == 4);
   sqlite3_finalize(pStmt);
 
   sqlite3_prepare_v2(

--- a/js/packages/node-tests/src/__tests__/user-reports.test.ts
+++ b/js/packages/node-tests/src/__tests__/user-reports.test.ts
@@ -52,6 +52,24 @@ test("failed to increment?", () => {
   `);
   expect(database.prepare(`SELECT * FROM crsql_changes`).all()).toEqual([
     {
+      cid: "__crsql_pko",
+      col_version: 1,
+      db_version: 1,
+      pk: Buffer.from(Uint8Array.from([1, 1])),
+      site_id: null,
+      table: "b",
+      val: null,
+    },
+    {
+      cid: "__crsql_pko",
+      col_version: 1,
+      db_version: 2,
+      pk: Buffer.from(Uint8Array.from([1, 9, 10])),
+      site_id: null,
+      table: "a",
+      val: null,
+    },
+    {
       table: "a",
       pk: Buffer.from(Uint8Array.from([1, 9, 10])),
       cid: "data",

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 source env/bin/activate
-python -m pytest tests -s
+python -m pytest tests -s -k test_schema_mod
 
 # -k test_sync_prop.py

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 source env/bin/activate
-python -m pytest tests -s -k test_seq.py
+python -m pytest tests -s 
 
 # -k test_sync_prop.py

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 source env/bin/activate
-python -m pytest tests -s -k test_schema_mod
+python -m pytest tests -s -k test_seq.py
 
 # -k test_sync_prop.py

--- a/py/correctness/tests/test_insert_new_rows.py
+++ b/py/correctness/tests/test_insert_new_rows.py
@@ -1,32 +1,31 @@
 from crsql_correctness import connect, min_db_v
+from pprint import pprint
+
 
 def test_c1_c2_c3_c4_c6_c7_crr_values():
-  c = connect(":memory:")
-  init_version = c.execute("SELECT crsql_dbversion()").fetchone()[0]
-  c.execute("create table foo (id primary key, a)")
-  c.execute("select crsql_as_crr('foo')")
+    c = connect(":memory:")
+    init_version = c.execute("SELECT crsql_dbversion()").fetchone()[0]
+    c.execute("create table foo (id primary key, a)")
+    c.execute("select crsql_as_crr('foo')")
 
-  c.execute("insert into foo values(1, 2)")
-  c.commit()
+    c.execute("insert into foo values(1, 2)")
+    c.commit()
 
-  row = c.execute("select id, __crsql_col_name, __crsql_col_version, __crsql_db_version, __crsql_site_id from foo__crsql_clock").fetchone()
-  assert row[0] == 1
-  assert row[1] == 'a'
-  assert row[2] == 1
-  assert row[3] == init_version + 1
-  assert row[4] == None
-  new_version = c.execute("SELECT crsql_dbversion()").fetchone()[0]
+    rows = c.execute(
+        "select id, __crsql_col_name, __crsql_col_version, __crsql_db_version, __crsql_site_id from foo__crsql_clock").fetchall()
+    assert [(1, '__crsql_pko', 1, init_version + 1, None),
+            (1, 'a', 1, init_version + 1, None)] == rows
+    new_version = c.execute("SELECT crsql_dbversion()").fetchone()[0]
 
-  assert new_version == init_version + 1
+    assert new_version == init_version + 1
 
-  clock_rows = c.execute("select * from foo__crsql_clock").fetchall()
-  assert len(clock_rows) == 1
+    clock_rows = c.execute("select * from foo__crsql_clock").fetchall()
+    assert len(clock_rows) == 2
 
-  row = c.execute("select id, a from foo").fetchone()
-  assert row[0] == 1
-  assert row[1] == 2
+    row = c.execute("select id, a from foo").fetchone()
+    assert row[0] == 1
+    assert row[1] == 2
 
-  new_version = c.execute("SELECT crsql_dbversion()").fetchone()[0]
+    new_version = c.execute("SELECT crsql_dbversion()").fetchone()[0]
 
-  assert new_version == init_version + 1
-
+    assert new_version == init_version + 1

--- a/py/correctness/tests/test_sandbox.py
+++ b/py/correctness/tests/test_sandbox.py
@@ -16,24 +16,34 @@ def test_sync():
     db1 = connect(":memory:")
     db2 = connect(":memory:")
 
-    db1.execute("CREATE TABLE foo (a primary key, b)")
-    db1.execute("SELECT crsql_as_crr('foo')")
-    db1.commit()
+    def setup(db):
+        db.execute("CREATE TABLE hoot (a, b primary key, c)")
+        db.execute("SELECT crsql_as_crr('hoot')")
+        db.commit()
 
-    db2.execute("CREATE TABLE foo (a primary key, b)")
-    db2.execute("SELECT crsql_as_crr('foo')")
-    db2.commit()
+        db.execute("INSERT INTO hoot VALUES (1, 1, 1)")
+        db.commit()
+        db.execute("UPDATE hoot SET a = 1 WHERE b = 1")
+        db.commit()
+        db.execute("UPDATE hoot SET a = 2 WHERE b = 1")
+        db.commit()
+        db.execute("UPDATE hoot SET a = 3 WHERE b = 1")
+        db.commit()
 
-    db1.execute("INSERT INTO foo VALUES (1, 2.0e2)")
-    db1.commit()
-    db2.execute("INSERT INTO foo VALUES (2, X'1232')")
-    db2.commit()
+    setup(db1)
+    setup(db2)
+
+    db1_v = db1.execute("SELECT crsql_dbversion()").fetchone()
+    db2_v = db2.execute("SELECT crsql_dbversion()").fetchone()
+
+    pprint(db1_v)
+    pprint(db2_v)
 
     sync_left_to_right(db1, db2)
 
-    # pprint(db1.execute("SELECT * FROM foo").fetchall())
-    # pprint(db1.execute("SELECT * FROM foo__crsql_clock").fetchall())
-    # pprint(db1.execute("SELECT * FROM crsql_changes").fetchall())
-    pprint(db2.execute("SELECT * FROM foo").fetchall())
-    pprint(db2.execute("SELECT * FROM foo__crsql_clock").fetchall())
+    db1_v = db1.execute("SELECT crsql_dbversion()").fetchone()
+    db2_v = db2.execute("SELECT crsql_dbversion()").fetchone()
+    pprint(db1_v)
+    pprint(db2_v)
+
     pprint(db2.execute("SELECT * FROM crsql_changes").fetchall())

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -125,23 +125,26 @@ def test_backfill_col_add():
     # Given we only migrate against compatible schema versions there's no need to create
     # a record of a default value. The other node will have the same default or, if they wrote a value,
     # a value which takes precedence.
-    assert (changes == [('todo', b'\x01\x09\x01', 'name', "cook"),
-                        ('todo', b'\x01\x09\x01', 'complete', 0),
-                        ('todo', b'\x01\x09\x01', 'list', "home")])
+    assert (changes == [('todo', b'\x01\t\x01', '__crsql_pko', None),
+                        ('todo', b'\x01\t\x01', 'name', 'cook'),
+                        ('todo', b'\x01\t\x01', 'complete', 0),
+                        ('todo', b'\x01\t\x01', 'list', 'home')])
 
     # we should be able to add entries
     c.execute(
         "INSERT INTO todo (id, name, complete, list, assignee) VALUES (2, 'clean', 0, 'home', 'me');")
     c.commit()
     changes = c.execute(changes_query).fetchall()
-    assert (changes == [('todo', b'\x01\x09\x01', 'name', "cook"),
-                        ('todo', b'\x01\x09\x01', 'complete', 0),
-                        ('todo', b'\x01\x09\x01', 'list', "home"),
-                        ('todo', b'\x01\x09\x02', 'name', "clean"),
-                        ('todo', b'\x01\x09\x02', 'complete', 0),
-                        ('todo', b'\x01\x09\x02', 'list', "home"),
-                        ('todo', b'\x01\x09\x02', 'assignee', "me"),
-                        ('todo', b'\x01\x09\x02', 'due_date', "2018-01-01")])
+    assert (changes == [('todo', b'\x01\t\x01', '__crsql_pko', None),
+                        ('todo', b'\x01\t\x01', 'name', 'cook'),
+                        ('todo', b'\x01\t\x01', 'complete', 0),
+                        ('todo', b'\x01\t\x01', 'list', 'home'),
+                        ('todo', b'\x01\t\x02', '__crsql_pko', None),
+                        ('todo', b'\x01\t\x02', 'name', 'clean'),
+                        ('todo', b'\x01\t\x02', 'complete', 0),
+                        ('todo', b'\x01\t\x02', 'list', 'home'),
+                        ('todo', b'\x01\t\x02', 'assignee', 'me'),
+                        ('todo', b'\x01\t\x02', 'due_date', '2018-01-01')])
 
 
 def test_merging_columns_with_no_metadata():
@@ -167,13 +170,14 @@ def test_backfill_clocks_on_rename():
     c.execute("SELECT crsql_commit_alter('todo');")
     c.commit()
     changes = c.execute(changes_with_versions_query).fetchall()
-
-    assert (changes == [('todo', b'\x01\x09\x01', 'complete', 0, 1, 1),
-                        ('todo', b'\x01\x09\x01', 'list', "home", 1, 1),
-                        ('todo', b'\x01\x09\x01', 'task', "cook", 2, 1),
-                        ('todo', b'\x01\x09\x02', 'complete', 0, 2, 1),
-                        ('todo', b'\x01\x09\x02', 'task', "clean", 2, 1),
-                        ('todo', b'\x01\x09\x02', 'list', "home", 2, 1)])
+    assert (changes == [('todo', b'\x01\t\x01', '__crsql_pko', None, 1, 1),
+                        ('todo', b'\x01\t\x01', 'complete', 0, 1, 1),
+                        ('todo', b'\x01\t\x01', 'list', 'home', 1, 1),
+                        ('todo', b'\x01\t\x02', '__crsql_pko', None, 2, 1),
+                        ('todo', b'\x01\t\x01', 'task', 'cook', 2, 1),
+                        ('todo', b'\x01\t\x02', 'complete', 0, 2, 1),
+                        ('todo', b'\x01\t\x02', 'list', 'home', 2, 1),
+                        ('todo', b'\x01\t\x02', 'task', 'clean', 2, 1)])
 
 
 def test_delete_sentinels_not_lost():
@@ -235,10 +239,12 @@ def test_backfill_existing_data():
     c.commit()
 
     changes = c.execute(changes_query).fetchall()
-
-    assert (changes == [('foo', b'\x01\x09\x01', 'name', "bar"),
-                        ('foo', b'\x01\x09\x02', 'name', "baz"),
-                        ('foo', b'\x01\x09\x03', 'name', None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None),
+                        ('foo', b'\x01\t\x01', 'name', 'bar'),
+                        ('foo', b'\x01\t\x02', '__crsql_pko', None),
+                        ('foo', b'\x01\t\x02', 'name', 'baz'),
+                        ('foo', b'\x01\t\x03', '__crsql_pko', None),
+                        ('foo', b'\x01\t\x03', 'name', None)])
 
 
 # This creates table which have existing data.
@@ -265,11 +271,16 @@ def test_backfill_moves_dbversion():
     c.commit()
 
     changes = c.execute(changes_with_versions_query).fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'name', "bar", 1, 1),  # first 2 are db_version 1
-                        ('foo', b'\x01\x09\x02', 'name', "baz", 1, 1),
-                        # next 2 are db_version 2
-                        ('bar', b'\x01\x09\x01', 'name', "bar", 2, 1),
-                        ('bar', b'\x01\x09\x03', 'name', None, 2, 1)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1),
+                        ('foo', b'\x01\t\x01', 'name', 'bar', 1, 1),
+                        ('foo', b'\x01\t\x02', '__crsql_pko', None, 1, 1),
+                        ('foo', b'\x01\t\x02', 'name',
+                         'baz', 1, 1),  # db version 1
+                        ('bar', b'\x01\t\x01', '__crsql_pko',
+                         None, 2, 1),  # db version 2
+                        ('bar', b'\x01\t\x01', 'name', 'bar', 2, 1),
+                        ('bar', b'\x01\t\x03', '__crsql_pko', None, 2, 1),
+                        ('bar', b'\x01\t\x03', 'name', None, 2, 1)])
 
 
 # Similar to the above test but checks that `crsql_alter` does the right thing.
@@ -304,11 +315,13 @@ def test_backfill_for_alter_does_not_move_dbversion():
     changes = c.execute(full_changes_query).fetchall()
     assert (changes ==
             # Existing rows have their existing db_version (1).
-            [('foo', b'\x01\x09\x01', 'name', "bar", 1, 1, None),
+            [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
              # New rows get the current db version given
              # migrations on other will create convergence.
-             ('foo', b'\x01\x09\x02', 'name', "baz", 1, 1, None),
-             ('foo', b'\x01\x09\x02', 'age', 33, 1, 1, None)])
+             ('foo', b'\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                ('foo', b'\x01\t\x01', 'name', 'bar', 1, 1, None),
+                ('foo', b'\x01\t\x02', 'name', 'baz', 1, 1, None),
+                ('foo', b'\x01\t\x02', 'age', 33, 1, 1, None)])
 
 
 def test_add_col_with_default():
@@ -325,7 +338,9 @@ def test_add_col_with_default():
     changes = c.execute(full_changes_query).fetchall()
     # No change given we only added a column with a default value and we need
     # not backfill default values
-    assert (changes == [('foo', b'\x01\x09\x01', 'name', "bar", 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'name', 'bar', 1, 1, None)])
+
     None
 
 
@@ -341,7 +356,8 @@ def test_add_col_nullable():
     c.execute("SELECT crsql_commit_alter('foo');")
 
     changes = c.execute(full_changes_query).fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'name', "bar", 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'name', 'bar', 1, 1, None)])
 
 
 def test_add_col_implicit_nullable():
@@ -356,7 +372,8 @@ def test_add_col_implicit_nullable():
     c.execute("SELECT crsql_commit_alter('foo');")
 
     changes = c.execute(full_changes_query).fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'name', "bar", 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'name', 'bar', 1, 1, None)])
 
 
 def test_add_col_through_12step():
@@ -379,13 +396,12 @@ def test_add_col_through_12step():
     c.execute("SELECT crsql_commit_alter('foo');")
 
     changes = c.execute(full_changes_query).fetchall()
-    assert (changes == [('foo', b'\x01\x09\x03', 'name', None, 1, 1, None),
-                        # New row (22) appropriately gets same db version
-                        # see create_clock_rows_from_stmt
-                        ('foo', b'\x01\x09\x16', 'name', "baz", 1, 1, None),
-                        ('foo', b'\x01\x09\x16', 'age', 33, 1, 1, None),
-                        # age was updated to a new value during migration so db_version appropriately incremented
-                        ('foo', b'\x01\x09\x03', 'age', 44, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x03', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x16', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x03', 'name', None, 1, 1, None),
+                        ('foo', b'\x01\t\x16', 'name', 'baz', 1, 1, None),
+                        ('foo', b'\x01\t\x16', 'age', 33, 1, 1, None),
+                        ('foo', b'\x01\t\x03', 'age', 44, 1, 1, None)])
 
 
 def test_pk_only_table_backfill():
@@ -418,8 +434,10 @@ def test_pk_and_default_backfill():
 
     changes = c.execute(full_changes_query).fetchall()
     # Rows should be backfilled
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', None, 1, 1,
-            None), ('foo', b'\x01\x09\x02', 'b', None, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', None, 1, 1, None),
+                        ('foo', b'\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x02', 'b', None, 1, 1, None)])
 
 
 def test_pk_and_default_backfill_post12step_with_new_rows():
@@ -450,8 +468,10 @@ def test_pk_and_default_backfill_post12step_with_new_rows():
     # 1. do schema alterations in begin/commit alter
     # 2. do data alterations after commit alter
     # data alterations will then get new db versions.
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', None, 0, 1,
-            None), ('foo', b'\x01\x09\x02', 'b', None, 0, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 0, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', None, 0, 1, None),
+                        ('foo', b'\x01\t\x02', '__crsql_pko', None, 0, 1, None),
+                        ('foo', b'\x01\t\x02', 'b', None, 0, 1, None)])
 
 
 def test_add_column_and_set_column():
@@ -542,10 +562,12 @@ def test_remove_col_from_pk():
     c.commit()
 
     changes = c.execute(full_changes_query).fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 1, None),
-                        ('foo', b'\x01\x09\x01', 'c', 3, 1, 1, None),
-                        ('foo', b'\x01\x09\x04', 'b', 5, 1, 1, None),
-                        ('foo', b'\x01\x09\x04', 'c', 6, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'c', 3, 1, 1, None),
+                        ('foo', b'\x01\t\x04', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x04', 'b', 5, 1, 1, None),
+                        ('foo', b'\x01\t\x04', 'c', 6, 1, 1, None)])
 
     None
 
@@ -571,8 +593,10 @@ def test_remove_pk_column():
     c.execute("SELECT crsql_commit_alter('foo');")
 
     changes = c.execute(full_changes_query).fetchall()
-    assert (changes == [('foo', b'\x01\x09\x02', 'c', 3, 1, 1, None),
-            ('foo', b'\x01\x09\x05', 'c', 6, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x02', 'c', 3, 1, 1, None),
+                        ('foo', b'\x01\t\x05', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x05', 'c', 6, 1, 1, None)])
 
 
 def test_add_existing_col_to_pk():
@@ -594,8 +618,11 @@ def test_add_existing_col_to_pk():
     c.execute("SELECT crsql_commit_alter('foo');")
 
     changes = c.execute(full_changes_query).fetchall()
-    assert (changes == [('foo', b'\x02\x09\x01\x09\x02', 'c', 3, 1, 1, None),
-            ('foo', b'\x02\x09\x04\x09\x05', 'c', 6, 1, 1, None)])
+    assert (changes == [('foo', b'\x02\t\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x02\t\x01\t\x02', 'c', 3, 1, 1, None),
+                        ('foo', b'\x02\t\x04\t\x05',
+                         '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x02\t\x04\t\x05', 'c', 6, 1, 1, None)])
 
 
 def test_add_new_col_to_pk():
@@ -617,9 +644,11 @@ def test_add_new_col_to_pk():
     c.execute("SELECT crsql_commit_alter('foo');")
 
     changes = c.execute(full_changes_query).fetchall()
-
-    assert (changes == [('foo', b'\x02\x09\x01\x09\x03', 'b', 2, 1, 1, None),
-            ('foo', b'\x02\x09\x04\x09\x06', 'b', 5, 1, 1, None)])
+    assert (changes == [('foo', b'\x02\t\x01\t\x03', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x02\t\x01\t\x03', 'b', 2, 1, 1, None),
+                        ('foo', b'\x02\t\x04\t\x06',
+                         '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x02\t\x04\t\x06', 'b', 5, 1, 1, None)])
 
 
 # DB version isn't bumped but this is fine...
@@ -649,8 +678,10 @@ def test_rename_pk_column():
 
     changes = c.execute(full_changes_query).fetchall()
 
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 1, None),
-            ('foo', b'\x01\x09\x04', 'b', 5, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None),
+                        ('foo', b'\x01\t\x04', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x04', 'b', 5, 1, 1, None)])
 
 
 def test_pk_only_table_pk_membership():
@@ -673,8 +704,13 @@ def test_changing_values_in_primary_key_columns():
     c.commit()
 
     changes = c.execute(full_changes_query).fetchall()
-    assert (changes == [('foo', b'\x01\x09\x02', 'b', 2, 1, 1, None),
-            ('foo', b'\x01\x09\x04', 'b', 5, 1, 1, None)])
+    # TODO: should we not be recording a delete fro `a = 1` given the row was last
+    # as a result of the migration? Hmm.. under the current rules of "no sync while schema mismatch"
+    # this shouldn't be required.
+    assert (changes == [('foo', b'\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x02', 'b', 2, 1, 1, None),
+                        ('foo', b'\x01\t\x04', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x04', 'b', 5, 1, 1, None)])
 
 
 def test_12step_backfill_retains_siteid():

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -74,19 +74,17 @@ def setup_alter_test():
 def test_drop_clock_on_col_remove():
     c = setup_alter_test()
     changes = c.execute(changes_query).fetchall()
-    expected = [
-        ('todo', b'\x01\x09\x01', 'name', "cook"),
-        ('todo', b'\x01\x09\x01', 'complete', 0),
-        ('todo', b'\x01\x09\x01', 'list', "home"),
-    ]
+    expected = [('todo', b'\x01\t\x01', '__crsql_pko', None),
+                ('todo', b'\x01\t\x01', 'name', 'cook'),
+                ('todo', b'\x01\t\x01', 'complete', 0),
+                ('todo', b'\x01\t\x01', 'list', 'home')]
     assert (changes == expected)
 
     clock_entries = c.execute(clock_query).fetchall()
-    assert (clock_entries == [
-        (1, 1, 1, 'name', None),
-        (2, 1, 1, 'complete', None),
-        (3, 1, 1, 'list', None),
-    ])
+    assert (clock_entries == [(1, 1, 1, '__crsql_pko', None),
+                              (2, 1, 1, 'name', None),
+                              (3, 1, 1, 'complete', None),
+                              (4, 1, 1, 'list', None)])
 
     c.execute("SELECT crsql_begin_alter('todo');")
     # Dropping a column should remove its entries from our replication logs.
@@ -96,6 +94,7 @@ def test_drop_clock_on_col_remove():
 
     changes = c.execute(changes_query).fetchall()
     expected = [
+        ('todo', b'\x01\t\x01', '__crsql_pko', None),
         ('todo', b'\x01\x09\x01', 'name', "cook"),
         ('todo', b'\x01\x09\x01', 'complete', 0),
     ]
@@ -103,7 +102,8 @@ def test_drop_clock_on_col_remove():
 
     clock_entries = c.execute(clock_query).fetchall()
     assert (
-        clock_entries == [(1, 1, 1, 'name', None), (2, 1, 1, 'complete', None)]
+        clock_entries == [(1, 1, 1, '__crsql_pko', None),
+                          (2, 1, 1, 'name', None), (3, 1, 1, 'complete', None)]
     )
 
 

--- a/py/correctness/tests/test_sync.py
+++ b/py/correctness/tests/test_sync.py
@@ -80,24 +80,32 @@ def test_changes_since():
     rows = get_changes_since(dbs[0], 0, "FF")
     # siteid = dbs[0].execute("select crsql_siteid()").fetchone()[0]
     siteid = None
-    expected = [('user', b'\x01\x09\x01', 'name', "Javi", 1, 1, None),
-                ('deck', b'\x01\x09\x01', 'owner_id', 1, 1, 1, None),
-                ('deck', b'\x01\x09\x01', 'title', "Preso", 1, 1, None),
-                ('slide', b'\x01\x09\x01', 'deck_id', 1, 1, 1, None),
-                ('slide', b'\x01\x09\x01', 'order', 0, 1, 1, None),
-                ('component', b'\x01\x09\x01', 'type', "text", 1, 1, None),
-                ('component', b'\x01\x09\x01', 'slide_id', 1, 1, 1, None),
-                ('component', b'\x01\x09\x01', 'content', "wootwoot", 1, 1, None),
-                ('component', b'\x01\x09\x02', 'type', "text", 1, 1, None),
-                ('component', b'\x01\x09\x02', 'slide_id', 1, 1, 1, None),
-                ('component', b'\x01\x09\x02', 'content', "toottoot", 1, 1, None),
-                ('component', b'\x01\x09\x03', 'type', "text", 1, 1, None),
-                ('component', b'\x01\x09\x03', 'slide_id', 1, 1, 1, None),
-                ('component', b'\x01\x09\x03', 'content', "footfoot", 1, 1, None),
-                ('slide', b'\x01\x09\x02', 'deck_id', 1, 1, 1, None),
-                ('slide', b'\x01\x09\x02', 'order', 1, 1, 1, None),
-                ('slide', b'\x01\x09\x03', 'deck_id', 1, 1, 1, None),
-                ('slide', b'\x01\x09\x03', 'order', 2, 1, 1, None)]
+    expected = [('user', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                ('user', b'\x01\t\x01', 'name', 'Javi', 1, 1, None),
+                ('deck', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                ('deck', b'\x01\t\x01', 'owner_id', 1, 1, 1, None),
+                ('deck', b'\x01\t\x01', 'title', 'Preso', 1, 1, None),
+                ('slide', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                ('slide', b'\x01\t\x01', 'deck_id', 1, 1, 1, None),
+                ('slide', b'\x01\t\x01', 'order', 0, 1, 1, None),
+                ('component', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                ('component', b'\x01\t\x01', 'type', 'text', 1, 1, None),
+                ('component', b'\x01\t\x01', 'slide_id', 1, 1, 1, None),
+                ('component', b'\x01\t\x01', 'content', 'wootwoot', 1, 1, None),
+                ('component', b'\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                ('component', b'\x01\t\x02', 'type', 'text', 1, 1, None),
+                ('component', b'\x01\t\x02', 'slide_id', 1, 1, 1, None),
+                ('component', b'\x01\t\x02', 'content', 'toottoot', 1, 1, None),
+                ('component', b'\x01\t\x03', '__crsql_pko', None, 1, 1, None),
+                ('component', b'\x01\t\x03', 'type', 'text', 1, 1, None),
+                ('component', b'\x01\t\x03', 'slide_id', 1, 1, 1, None),
+                ('component', b'\x01\t\x03', 'content', 'footfoot', 1, 1, None),
+                ('slide', b'\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                ('slide', b'\x01\t\x02', 'deck_id', 1, 1, 1, None),
+                ('slide', b'\x01\t\x02', 'order', 1, 1, 1, None),
+                ('slide', b'\x01\t\x03', '__crsql_pko', None, 1, 1, None),
+                ('slide', b'\x01\t\x03', 'deck_id', 1, 1, 1, None),
+                ('slide', b'\x01\t\x03', 'order', 2, 1, 1, None)]
 
     assert (rows == expected)
 
@@ -129,17 +137,15 @@ def test_delete():
 
     rows = get_changes_since(db, 0, 'FF')
     # TODO: should deletes not get a proper version? Would be better for ordering and chunking replications
-    assert (rows == [('user', b'\x01\x09\x01', 'name', "Javi", 1, 1, None),
-                     ('component', b'\x01\x09\x01',
-                      '__crsql_del', None, 1, 2, None),
-                     ('component', b'\x01\x09\x02',
-                      '__crsql_del', None, 1, 3, None),
-                     ('component', b'\x01\x09\x03',
-                      '__crsql_del', None, 1, 3, None),
-                     ('deck', b'\x01\x09\x01', '__crsql_del', None, 1, 3, None),
-                     ('slide', b'\x01\x09\x01', '__crsql_del', None, 1, 3, None),
-                     ('slide', b'\x01\x09\x02', '__crsql_del', None, 1, 3, None),
-                     ('slide', b'\x01\x09\x03', '__crsql_del', None, 1, 3, None)])
+    assert (rows == [('user', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                     ('user', b'\x01\t\x01', 'name', 'Javi', 1, 1, None),
+                     ('component', b'\x01\t\x01', '__crsql_del', None, 1, 2, None),
+                     ('component', b'\x01\t\x02', '__crsql_del', None, 1, 3, None),
+                     ('component', b'\x01\t\x03', '__crsql_del', None, 1, 3, None),
+                     ('deck', b'\x01\t\x01', '__crsql_del', None, 1, 3, None),
+                     ('slide', b'\x01\t\x01', '__crsql_del', None, 1, 3, None),
+                     ('slide', b'\x01\t\x02', '__crsql_del', None, 1, 3, None),
+                     ('slide', b'\x01\t\x03', '__crsql_del', None, 1, 3, None)])
 
     # test insert
 
@@ -179,7 +185,8 @@ def test_merging_on_defaults():
     # db2 set b to 2 this should be the winner
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
     # w a db version change since a write happened
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 2, None)])
 
     close(db1)
     close(db2)
@@ -192,7 +199,8 @@ def test_merging_on_defaults():
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # db1 into db2
     # db2 should still win w. no db version change since no write happened
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None)])
 
     # test merging from thing without records (db1) to thing with records (db2)
 
@@ -233,7 +241,8 @@ def test_merging_larger_backfilled_default():
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # db version is pushed since 4 wins the col_version tie
     # col version stays since 1 is the max of winner and loser.
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 4, 1, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 4, 1, 2, None)])
 
 
 def test_merging_larger():
@@ -265,13 +274,17 @@ def test_db_version_moves_as_expected_post_alter():
     db.commit()
 
     changes = db.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 1, None),
-                        ('foo', b'\x01\x09\x02', 'b', 3, 1, 2, None),
-                        ('foo', b'\x01\x09\x02', 'c', 4, 1, 2, None),
-                        ('foo', b'\x01\x09\x03', 'b', 4, 1, 3, None),
-                        ('foo', b'\x01\x09\x03', 'c', 5, 1, 3, None),
-                        ('foo', b'\x01\x09\x04', 'b', 4, 1, 4, None),
-                        ('foo', b'\x01\x09\x04', 'c', 5, 1, 4, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None),
+                        ('foo', b'\x01\t\x02', '__crsql_pko', None, 1, 2, None),
+                        ('foo', b'\x01\t\x02', 'b', 3, 1, 2, None),
+                        ('foo', b'\x01\t\x02', 'c', 4, 1, 2, None),
+                        ('foo', b'\x01\t\x03', '__crsql_pko', None, 1, 3, None),
+                        ('foo', b'\x01\t\x03', 'b', 4, 1, 3, None),
+                        ('foo', b'\x01\t\x03', 'c', 5, 1, 3, None),
+                        ('foo', b'\x01\t\x04', '__crsql_pko', None, 1, 4, None),
+                        ('foo', b'\x01\t\x04', 'b', 4, 1, 4, None),
+                        ('foo', b'\x01\t\x04', 'c', 5, 1, 4, None)])
 
 
 # DB1 has a row with no clock records (added during schema modification)
@@ -317,8 +330,9 @@ def test_merging_on_defaults2():
     sync_left_to_right(db2, db1, 0)
 
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 4, 1, 1, None),
-            ('foo', b'\x01\x09\x01', 'c', 3, 1, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 4, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'c', 3, 1, 2, None)])
 
     close(db1)
     close(db2)
@@ -329,12 +343,13 @@ def test_merging_on_defaults2():
     sync_left_to_right(db1, db2, 0)
 
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    # db2 c 3 wins given columns with no value after an alter
-    # do no merging
-    assert (changes == [('foo', b'\x01\x09\x01', 'c', 3, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        # db2 c 3 wins given columns with no value after an alter
+                        # do no merging
+                        ('foo', b'\x01\t\x01', 'c', 3, 1, 1, None),
                         # Move db version since b lost on db2.
                         # b had the value 2 on db2.
-                        ('foo', b'\x01\x09\x01', 'b', 4, 1, 2, None)])
+                        ('foo', b'\x01\t\x01', 'b', 4, 1, 2, None)])
 
 
 def create_basic_db():
@@ -361,13 +376,15 @@ def test_merge_same():
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # all at base version
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # all at base version
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None)])
 
 
 def test_merge_matching_clocks_lesser_value():
@@ -386,13 +403,15 @@ def test_merge_matching_clocks_lesser_value():
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # no change since incoming is lesser
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 1, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
     # change since incoming is greater
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 1, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 1, 2, None)])
 
 
 def test_merge_larger_clock_larger_value():
@@ -412,12 +431,14 @@ def test_merge_larger_clock_larger_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 3, 2, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 3, 2, 2, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 3, 2, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 3, 2, 2, None)])
 
 
 def test_merge_larger_clock_smaller_value():
@@ -437,12 +458,14 @@ def test_merge_larger_clock_smaller_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 0, 2, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 0, 2, 2, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 0, 2, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 0, 2, 2, None)])
 
 
 def test_merge_larger_clock_same_value():
@@ -462,12 +485,14 @@ def test_merge_larger_clock_same_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 2, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 2, 2, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\x09\x01', 'b', 2, 2, 2, None)])
+    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                        ('foo', b'\x01\t\x01', 'b', 2, 2, 2, None)])
 
 # Row exists but col added thus no defaults backfilled
 


### PR DESCRIPTION
Rather than moving 100% to a model that can support re-insertions immediately, I decided to break the work up into chunks.

Re-insertion requires us to keep a metadata at the row level on initial row creation. This diff adds that. (note: I'm a bit concerned about metadata growth so a follow on improvement would be to restructure our metadata format so it is smaller: #293. Looks like we can compress by 5x in average case!).

A nice side-effect is that this diff also solved all the primary key modification issues ( #50). I.e., when doing an `UPDATE` to change a primary key from one value to another, this is actually a `DELETE` of the row with the old primary key and `INSERT` of the row with the new one since a primary key is the identity of a row.

Follow on diffs would be to:

- Keep delete-wins semantics but collapse delete and create metadata into a single row. A `delete` is where `col_version = 2` and a `create` is where `col_version = 1`
- Iterate on the above change to fully respect causal length semantics