### PR TITLE
use a single sentinel column to represent delete and create

### DIFF
--- a/core/rs/core/src/alter.rs
+++ b/core/rs/core/src/alter.rs
@@ -90,7 +90,7 @@ unsafe fn compact_post_alter(
         // Next delete entries that no longer have a row
         let mut sql = String::from(
             format!(
-              "DELETE FROM \"{tbl_name}__crsql_clock\" WHERE __crsql_col_name != '__crsql_del' AND NOT EXISTS (SELECT 1 FROM \"{tbl_name}\" WHERE ",
+              "DELETE FROM \"{tbl_name}__crsql_clock\" WHERE __crsql_col_name != '-1' AND NOT EXISTS (SELECT 1 FROM \"{tbl_name}\" WHERE ",
               tbl_name = crate::util::escape_ident(tbl_name_str),
             ),
         );

--- a/core/rs/core/src/c.rs
+++ b/core/rs/core/src/c.rs
@@ -7,10 +7,8 @@ use num_derive::FromPrimitive;
 // As well as functions re-defined in Rust but not yet deleted from C
 use sqlite_nostd as sqlite;
 
-pub static INSERT_SENTINEL: &str = "__crsql_pko";
-pub static DELETE_SENTINEL: &str = "__crsql_del";
-// pub static INSERT_SENTINEL_CSTR: &str = "__crsql_pko\0";
-// pub static DELETE_SENTINEL_CSTR: &str = "__crsql_del\0";
+pub static INSERT_SENTINEL: &str = "-1";
+pub static DELETE_SENTINEL: &str = "-1";
 
 #[derive(FromPrimitive, PartialEq, Debug)]
 pub enum CrsqlChangesColumn {

--- a/core/rs/core/src/changes_vtab_write.rs
+++ b/core/rs/core/src/changes_vtab_write.rs
@@ -134,7 +134,7 @@ fn check_for_local_delete(
 
     let check_del_stmt = get_cached_stmt_rt_wt(db, ext_data, stmt_key, || {
         format!(
-          "SELECT 1 FROM \"{table_name}__crsql_clock\" WHERE {pk_where_list} AND __crsql_col_name = '{delete_sentinel}' LIMIT 1",
+          "SELECT 1 FROM \"{table_name}__crsql_clock\" WHERE {pk_where_list} AND __crsql_col_name = '{delete_sentinel}' AND __crsql_col_version % 2 = 0 LIMIT 1",
           table_name = crate::util::escape_ident(tbl_name),
           pk_where_list = pk_where_list,
           delete_sentinel = crate::c::DELETE_SENTINEL,
@@ -482,8 +482,8 @@ unsafe fn merge_insert(
 
     let tbl_info = tbl_infos[tbl_info_index as usize];
 
-    let is_delete = crate::c::DELETE_SENTINEL == insert_col;
-    let is_pk_only = crate::c::INSERT_SENTINEL == insert_col;
+    let is_delete = crate::c::DELETE_SENTINEL == insert_col && insert_col_vrsn % 2 == 0;
+    let is_pk_only = crate::c::INSERT_SENTINEL == insert_col && insert_col_vrsn % 2 == 1;
 
     let pk_cols = sqlite::args!((*tbl_info).pksLen, (*tbl_info).pks);
     let pk_where_list = util::where_list(pk_cols)?;

--- a/core/rs/integration-check/tests/backfill.rs
+++ b/core/rs/integration-check/tests/backfill.rs
@@ -60,7 +60,7 @@ fn new_nonempty_table_impl(apply_twice: bool) -> Result<(), ResultCode> {
                 stmt.column_int64(0)?,
                 ((cnt + 1) as f64 / 2.0).ceil() as i64
             ); // pk
-            assert_eq!(stmt.column_text(1)?, "__crsql_pko"); // col name
+            assert_eq!(stmt.column_text(1)?, "-1"); // col name
             assert_eq!(stmt.column_int64(2)?, 1); // col version
             assert_eq!(stmt.column_int64(3)?, 1); // db version
         } else {
@@ -92,7 +92,7 @@ fn new_nonempty_table_impl(apply_twice: bool) -> Result<(), ResultCode> {
         }
         assert_eq!(stmt.column_text(0)?, "foo"); // table name
         if cnt % 2 == 0 {
-            assert_eq!(stmt.column_text(2)?, "__crsql_pko"); // col name
+            assert_eq!(stmt.column_text(2)?, "-1"); // col name
         } else {
             assert_eq!(stmt.column_text(2)?, "name"); // col name
         }

--- a/core/rs/integration-check/tests/pk_only_tables.rs
+++ b/core/rs/integration-check/tests/pk_only_tables.rs
@@ -263,7 +263,7 @@ fn discord_report_1_impl() -> Result<(), ResultCode> {
     let pk_val = stmt.column_blob(1)?;
     assert_eq!(pk_val, [0x01, 0x09, 0x2A]);
     let cid = stmt.column_text(2)?;
-    assert_eq!(cid, "__crsql_pko");
+    assert_eq!(cid, "-1");
     let val_type = stmt.column_type(3)?;
     assert_eq!(val_type, ColumnType::Null);
     let col_version = stmt.column_int64(4)?;

--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -351,8 +351,7 @@ static void testSelectChangesAfterChangingColumnName() {
   // clock records should now be for column `c` with a `null` value.
   // nit: test if a default value is set for the column
   while ((rc = sqlite3_step(pStmt)) == SQLITE_ROW) {
-    assert(strcmp((const char *)sqlite3_column_text(pStmt, 0), "__crsql_pko") ==
-           0);
+    assert(strcmp((const char *)sqlite3_column_text(pStmt, 0), "-1") == 0);
     assert(sqlite3_column_type(pStmt, 1) == SQLITE_NULL);
     ++numRows;
   }
@@ -386,8 +385,8 @@ static void testSelectChangesAfterChangingColumnName() {
     }
 
     if (numRows == 1 || numRows == 0) {
-      assert(strcmp("__crsql_pko", (const char *)sqlite3_column_text(
-                                       pStmt, CHANGES_SINCE_VTAB_CID)) == 0);
+      assert(strcmp("-1", (const char *)sqlite3_column_text(
+                              pStmt, CHANGES_SINCE_VTAB_CID)) == 0);
     }
     if (numRows == 2) {
       assert(strcmp("c", (const char *)sqlite3_column_text(

--- a/core/src/rows-impacted.test.c
+++ b/core/src/rows-impacted.test.c
@@ -249,7 +249,7 @@ static void testDeleteThatDoesNotChangeAnything() {
   rc += sqlite3_exec(
       db,
       "INSERT INTO crsql_changes VALUES ('foo', crsql_pack_columns(1), "
-      "'__crsql_del', NULL, 1, 2, NULL)",
+      "'-1', NULL, 2, 2, NULL)",  //__crsql_del
       0, 0, &err);
   sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
   sqlite3_step(pStmt);
@@ -274,7 +274,7 @@ static void testDelete() {
   rc += sqlite3_exec(db, "BEGIN", 0, 0, 0);
   rc += sqlite3_exec(db,
                      "INSERT INTO crsql_changes VALUES ('foo', X'010901', "
-                     "'__crsql_del', NULL, 1, 2, NULL)",
+                     "'-1', NULL, 2, 2, NULL)",  //__crsql_del
                      0, 0, &err);
   sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
   sqlite3_step(pStmt);

--- a/js/packages/node-tests/src/__tests__/user-reports.test.ts
+++ b/js/packages/node-tests/src/__tests__/user-reports.test.ts
@@ -20,7 +20,7 @@ test("pk only table", () => {
     {
       table: "data",
       pk: Buffer.from(Uint8Array.from([1, 9, 42])),
-      cid: "__crsql_pko",
+      cid: "-1",
       val: null,
       col_version: 1,
       db_version: 1,
@@ -52,7 +52,7 @@ test("failed to increment?", () => {
   `);
   expect(database.prepare(`SELECT * FROM crsql_changes`).all()).toEqual([
     {
-      cid: "__crsql_pko",
+      cid: "-1",
       col_version: 1,
       db_version: 1,
       pk: Buffer.from(Uint8Array.from([1, 1])),
@@ -61,7 +61,7 @@ test("failed to increment?", () => {
       val: null,
     },
     {
-      cid: "__crsql_pko",
+      cid: "-1",
       col_version: 1,
       db_version: 2,
       pk: Buffer.from(Uint8Array.from([1, 9, 10])),

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 source env/bin/activate
-python -m pytest tests -s 
+python -m pytest tests -s
 
 # -k test_sync_prop.py

--- a/py/correctness/tests/test_insert_new_rows.py
+++ b/py/correctness/tests/test_insert_new_rows.py
@@ -13,7 +13,7 @@ def test_c1_c2_c3_c4_c6_c7_crr_values():
 
     rows = c.execute(
         "select id, __crsql_col_name, __crsql_col_version, __crsql_db_version, __crsql_site_id from foo__crsql_clock").fetchall()
-    assert [(1, '__crsql_pko', 1, init_version + 1, None),
+    assert [(1, '-1', 1, init_version + 1, None),
             (1, 'a', 1, init_version + 1, None)] == rows
     new_version = c.execute("SELECT crsql_dbversion()").fetchone()[0]
 

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -74,14 +74,14 @@ def setup_alter_test():
 def test_drop_clock_on_col_remove():
     c = setup_alter_test()
     changes = c.execute(changes_query).fetchall()
-    expected = [('todo', b'\x01\t\x01', '__crsql_pko', None),
+    expected = [('todo', b'\x01\t\x01', '-1', None),
                 ('todo', b'\x01\t\x01', 'name', 'cook'),
                 ('todo', b'\x01\t\x01', 'complete', 0),
                 ('todo', b'\x01\t\x01', 'list', 'home')]
     assert (changes == expected)
 
     clock_entries = c.execute(clock_query).fetchall()
-    assert (clock_entries == [(1, 1, 1, '__crsql_pko', None),
+    assert (clock_entries == [(1, 1, 1, '-1', None),
                               (2, 1, 1, 'name', None),
                               (3, 1, 1, 'complete', None),
                               (4, 1, 1, 'list', None)])
@@ -94,7 +94,7 @@ def test_drop_clock_on_col_remove():
 
     changes = c.execute(changes_query).fetchall()
     expected = [
-        ('todo', b'\x01\t\x01', '__crsql_pko', None),
+        ('todo', b'\x01\t\x01', '-1', None),
         ('todo', b'\x01\x09\x01', 'name', "cook"),
         ('todo', b'\x01\x09\x01', 'complete', 0),
     ]
@@ -102,7 +102,7 @@ def test_drop_clock_on_col_remove():
 
     clock_entries = c.execute(clock_query).fetchall()
     assert (
-        clock_entries == [(1, 1, 1, '__crsql_pko', None),
+        clock_entries == [(1, 1, 1, '-1', None),
                           (2, 1, 1, 'name', None), (3, 1, 1, 'complete', None)]
     )
 
@@ -125,7 +125,7 @@ def test_backfill_col_add():
     # Given we only migrate against compatible schema versions there's no need to create
     # a record of a default value. The other node will have the same default or, if they wrote a value,
     # a value which takes precedence.
-    assert (changes == [('todo', b'\x01\t\x01', '__crsql_pko', None),
+    assert (changes == [('todo', b'\x01\t\x01', '-1', None),
                         ('todo', b'\x01\t\x01', 'name', 'cook'),
                         ('todo', b'\x01\t\x01', 'complete', 0),
                         ('todo', b'\x01\t\x01', 'list', 'home')])
@@ -135,11 +135,11 @@ def test_backfill_col_add():
         "INSERT INTO todo (id, name, complete, list, assignee) VALUES (2, 'clean', 0, 'home', 'me');")
     c.commit()
     changes = c.execute(changes_query).fetchall()
-    assert (changes == [('todo', b'\x01\t\x01', '__crsql_pko', None),
+    assert (changes == [('todo', b'\x01\t\x01', '-1', None),
                         ('todo', b'\x01\t\x01', 'name', 'cook'),
                         ('todo', b'\x01\t\x01', 'complete', 0),
                         ('todo', b'\x01\t\x01', 'list', 'home'),
-                        ('todo', b'\x01\t\x02', '__crsql_pko', None),
+                        ('todo', b'\x01\t\x02', '-1', None),
                         ('todo', b'\x01\t\x02', 'name', 'clean'),
                         ('todo', b'\x01\t\x02', 'complete', 0),
                         ('todo', b'\x01\t\x02', 'list', 'home'),
@@ -170,10 +170,10 @@ def test_backfill_clocks_on_rename():
     c.execute("SELECT crsql_commit_alter('todo');")
     c.commit()
     changes = c.execute(changes_with_versions_query).fetchall()
-    assert (changes == [('todo', b'\x01\t\x01', '__crsql_pko', None, 1, 1),
+    assert (changes == [('todo', b'\x01\t\x01', '-1', None, 1, 1),
                         ('todo', b'\x01\t\x01', 'complete', 0, 1, 1),
                         ('todo', b'\x01\t\x01', 'list', 'home', 1, 1),
-                        ('todo', b'\x01\t\x02', '__crsql_pko', None, 2, 1),
+                        ('todo', b'\x01\t\x02', '-1', None, 2, 1),
                         ('todo', b'\x01\t\x01', 'task', 'cook', 2, 1),
                         ('todo', b'\x01\t\x02', 'complete', 0, 2, 1),
                         ('todo', b'\x01\t\x02', 'list', 'home', 2, 1),
@@ -207,7 +207,7 @@ def test_pk_only_sentinels():
 
     changes = c.execute(changes_query).fetchall()
     assert (
-        changes == [('assoc', b'\x02\x09\x01\x09\x02', '__crsql_pko', None)])
+        changes == [('assoc', b'\x02\x09\x01\x09\x02', '-1', None)])
 
     c.execute("SELECT crsql_begin_alter('assoc');")
     c.execute("ALTER TABLE assoc ADD COLUMN data;")

--- a/py/correctness/tests/test_seq.py
+++ b/py/correctness/tests/test_seq.py
@@ -145,7 +145,8 @@ def test_incr_by_one():
     c.execute("UPDATE baz SET a = 11 WHERE a = 1")
     c.execute("UPDATE baz SET a = 22 WHERE a = 2")
     c.commit()
-    rows = c.execute("SELECT __crsql_seq FROM baz__crsql_clock").fetchall()
+    rows = c.execute(
+        "SELECT __crsql_seq FROM baz__crsql_clock ORDER BY __crsql_db_version, __crsql_seq ASC").fetchall()
     assert (rows == [(0,), (1,), (2,), (3,)])
 
     # c.execute("DELETE FROM baz")

--- a/py/correctness/tests/test_sync.py
+++ b/py/correctness/tests/test_sync.py
@@ -80,30 +80,30 @@ def test_changes_since():
     rows = get_changes_since(dbs[0], 0, "FF")
     # siteid = dbs[0].execute("select crsql_siteid()").fetchone()[0]
     siteid = None
-    expected = [('user', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    expected = [('user', b'\x01\t\x01', '-1', None, 1, 1, None),
                 ('user', b'\x01\t\x01', 'name', 'Javi', 1, 1, None),
-                ('deck', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                ('deck', b'\x01\t\x01', '-1', None, 1, 1, None),
                 ('deck', b'\x01\t\x01', 'owner_id', 1, 1, 1, None),
                 ('deck', b'\x01\t\x01', 'title', 'Preso', 1, 1, None),
-                ('slide', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                ('slide', b'\x01\t\x01', '-1', None, 1, 1, None),
                 ('slide', b'\x01\t\x01', 'deck_id', 1, 1, 1, None),
                 ('slide', b'\x01\t\x01', 'order', 0, 1, 1, None),
-                ('component', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+                ('component', b'\x01\t\x01', '-1', None, 1, 1, None),
                 ('component', b'\x01\t\x01', 'type', 'text', 1, 1, None),
                 ('component', b'\x01\t\x01', 'slide_id', 1, 1, 1, None),
                 ('component', b'\x01\t\x01', 'content', 'wootwoot', 1, 1, None),
-                ('component', b'\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                ('component', b'\x01\t\x02', '-1', None, 1, 1, None),
                 ('component', b'\x01\t\x02', 'type', 'text', 1, 1, None),
                 ('component', b'\x01\t\x02', 'slide_id', 1, 1, 1, None),
                 ('component', b'\x01\t\x02', 'content', 'toottoot', 1, 1, None),
-                ('component', b'\x01\t\x03', '__crsql_pko', None, 1, 1, None),
+                ('component', b'\x01\t\x03', '-1', None, 1, 1, None),
                 ('component', b'\x01\t\x03', 'type', 'text', 1, 1, None),
                 ('component', b'\x01\t\x03', 'slide_id', 1, 1, 1, None),
                 ('component', b'\x01\t\x03', 'content', 'footfoot', 1, 1, None),
-                ('slide', b'\x01\t\x02', '__crsql_pko', None, 1, 1, None),
+                ('slide', b'\x01\t\x02', '-1', None, 1, 1, None),
                 ('slide', b'\x01\t\x02', 'deck_id', 1, 1, 1, None),
                 ('slide', b'\x01\t\x02', 'order', 1, 1, 1, None),
-                ('slide', b'\x01\t\x03', '__crsql_pko', None, 1, 1, None),
+                ('slide', b'\x01\t\x03', '-1', None, 1, 1, None),
                 ('slide', b'\x01\t\x03', 'deck_id', 1, 1, 1, None),
                 ('slide', b'\x01\t\x03', 'order', 2, 1, 1, None)]
 
@@ -128,7 +128,7 @@ def test_delete():
     siteid = None
     # Deletes are marked with a sentinel id
     assert (rows == [('component', b'\x01\x09\x01',
-            '__crsql_del', None, 1, 2, siteid)])
+            '-1', None, 2, 2, siteid)])
 
     db.execute("DELETE FROM component")
     db.execute("DELETE FROM deck")
@@ -137,15 +137,15 @@ def test_delete():
 
     rows = get_changes_since(db, 0, 'FF')
     # TODO: should deletes not get a proper version? Would be better for ordering and chunking replications
-    assert (rows == [('user', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (rows == [('user', b'\x01\t\x01', '-1', None, 1, 1, None),
                      ('user', b'\x01\t\x01', 'name', 'Javi', 1, 1, None),
-                     ('component', b'\x01\t\x01', '__crsql_del', None, 1, 2, None),
-                     ('component', b'\x01\t\x02', '__crsql_del', None, 1, 3, None),
-                     ('component', b'\x01\t\x03', '__crsql_del', None, 1, 3, None),
-                     ('deck', b'\x01\t\x01', '__crsql_del', None, 1, 3, None),
-                     ('slide', b'\x01\t\x01', '__crsql_del', None, 1, 3, None),
-                     ('slide', b'\x01\t\x02', '__crsql_del', None, 1, 3, None),
-                     ('slide', b'\x01\t\x03', '__crsql_del', None, 1, 3, None)])
+                     ('component', b'\x01\t\x01', '-1', None, 2, 2, None),
+                     ('component', b'\x01\t\x02', '-1', None, 2, 3, None),
+                     ('component', b'\x01\t\x03', '-1', None, 2, 3, None),
+                     ('deck', b'\x01\t\x01', '-1', None, 2, 3, None),
+                     ('slide', b'\x01\t\x01', '-1', None, 2, 3, None),
+                     ('slide', b'\x01\t\x02', '-1', None, 2, 3, None),
+                     ('slide', b'\x01\t\x03', '-1', None, 2, 3, None)])
 
     # test insert
 
@@ -185,7 +185,7 @@ def test_merging_on_defaults():
     # db2 set b to 2 this should be the winner
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
     # w a db version change since a write happened
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 1, 2, None)])
 
     close(db1)
@@ -199,7 +199,7 @@ def test_merging_on_defaults():
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # db1 into db2
     # db2 should still win w. no db version change since no write happened
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None)])
 
     # test merging from thing without records (db1) to thing with records (db2)
@@ -241,7 +241,7 @@ def test_merging_larger_backfilled_default():
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # db version is pushed since 4 wins the col_version tie
     # col version stays since 1 is the max of winner and loser.
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 4, 1, 2, None)])
 
 
@@ -274,15 +274,15 @@ def test_db_version_moves_as_expected_post_alter():
     db.commit()
 
     changes = db.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None),
-                        ('foo', b'\x01\t\x02', '__crsql_pko', None, 1, 2, None),
+                        ('foo', b'\x01\t\x02', '-1', None, 1, 2, None),
                         ('foo', b'\x01\t\x02', 'b', 3, 1, 2, None),
                         ('foo', b'\x01\t\x02', 'c', 4, 1, 2, None),
-                        ('foo', b'\x01\t\x03', '__crsql_pko', None, 1, 3, None),
+                        ('foo', b'\x01\t\x03', '-1', None, 1, 3, None),
                         ('foo', b'\x01\t\x03', 'b', 4, 1, 3, None),
                         ('foo', b'\x01\t\x03', 'c', 5, 1, 3, None),
-                        ('foo', b'\x01\t\x04', '__crsql_pko', None, 1, 4, None),
+                        ('foo', b'\x01\t\x04', '-1', None, 1, 4, None),
                         ('foo', b'\x01\t\x04', 'b', 4, 1, 4, None),
                         ('foo', b'\x01\t\x04', 'c', 5, 1, 4, None)])
 
@@ -330,7 +330,7 @@ def test_merging_on_defaults2():
     sync_left_to_right(db2, db1, 0)
 
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 4, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'c', 3, 1, 2, None)])
 
@@ -343,7 +343,7 @@ def test_merging_on_defaults2():
     sync_left_to_right(db1, db2, 0)
 
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         # db2 c 3 wins given columns with no value after an alter
                         # do no merging
                         ('foo', b'\x01\t\x01', 'c', 3, 1, 1, None),
@@ -376,14 +376,14 @@ def test_merge_same():
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # all at base version
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # all at base version
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None)])
 
 
@@ -403,14 +403,14 @@ def test_merge_matching_clocks_lesser_value():
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # no change since incoming is lesser
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 1, 1, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
     # change since incoming is greater
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 1, 2, None)])
 
 
@@ -431,13 +431,13 @@ def test_merge_larger_clock_larger_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 3, 2, 2, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 3, 2, 2, None)])
 
 
@@ -458,13 +458,13 @@ def test_merge_larger_clock_smaller_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 0, 2, 2, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 0, 2, 2, None)])
 
 
@@ -485,13 +485,13 @@ def test_merge_larger_clock_same_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 2, 2, None)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', '__crsql_pko', None, 1, 1, None),
+    assert (changes == [('foo', b'\x01\t\x01', '-1', None, 1, 1, None),
                         ('foo', b'\x01\t\x01', 'b', 2, 2, 2, None)])
 
 # Row exists but col added thus no defaults backfilled


### PR DESCRIPTION
A follow up to #292 and the next step in supporting re-insertion.

Re-insertion needs to track causal length in a single metadata entry for the row. This collapses delete and create metadata to a single row but still uses delete-wins semantics.

Next PR will switch to causal length semantics.