### PR TITLE
fix ordinal mapping -- don't re-insert if it is present!

### DIFF
--- a/core/rs/core/src/c.rs
+++ b/core/rs/core/src/c.rs
@@ -86,6 +86,7 @@ pub struct crsql_ExtData {
     pub pSetSyncBitStmt: *mut sqlite::stmt,
     pub pClearSyncBitStmt: *mut sqlite::stmt,
     pub pSetSiteIdOrdinalStmt: *mut sqlite::stmt,
+    pub pSelectSiteIdOrdinalStmt: *mut sqlite::stmt,
     pub pStmtCache: *mut ::core::ffi::c_void,
 }
 
@@ -439,7 +440,7 @@ fn bindgen_test_layout_crsql_ExtData() {
     let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<crsql_ExtData>(),
-        112usize,
+        120usize,
         concat!("Size of: ", stringify!(crsql_ExtData))
     );
     assert_eq!(
@@ -600,8 +601,18 @@ fn bindgen_test_layout_crsql_ExtData() {
         )
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).pStmtCache) as usize - ptr as usize },
+        unsafe { ::std::ptr::addr_of!((*ptr).pSelectSiteIdOrdinalStmt) as usize - ptr as usize },
         104usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(crsql_ExtData),
+            "::",
+            stringify!(pSelectSiteIdOrdinalStmt)
+        )
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).pStmtCache) as usize - ptr as usize },
+        112usize,
         concat!(
             "Offset of field: ",
             stringify!(crsql_ExtData),

--- a/core/src/ext-data.c
+++ b/core/src/ext-data.c
@@ -27,10 +27,13 @@ crsql_ExtData *crsql_newExtData(sqlite3 *db, unsigned char *siteIdBuffer) {
 
   pExtData->pSetSiteIdOrdinalStmt = 0;
   rc += sqlite3_prepare_v3(
-      db,
-      "INSERT INTO crsql_site_id (site_id) VALUES (?) ON CONFLICT DO "
-      "UPDATE SET ordinal = ordinal RETURNING ordinal",
+      db, "INSERT INTO crsql_site_id (site_id) VALUES (?) RETURNING ordinal",
       -1, SQLITE_PREPARE_PERSISTENT, &(pExtData->pSetSiteIdOrdinalStmt), 0);
+
+  pExtData->pSelectSiteIdOrdinalStmt = 0;
+  rc += sqlite3_prepare_v3(
+      db, "SELECT ordinal FROM crsql_site_id WHERE site_id = ?", -1,
+      SQLITE_PREPARE_PERSISTENT, &(pExtData->pSelectSiteIdOrdinalStmt), 0);
 
   pExtData->dbVersion = -1;
   pExtData->seq = 0;
@@ -62,6 +65,7 @@ void crsql_freeExtData(crsql_ExtData *pExtData) {
   sqlite3_finalize(pExtData->pSetSyncBitStmt);
   sqlite3_finalize(pExtData->pClearSyncBitStmt);
   sqlite3_finalize(pExtData->pSetSiteIdOrdinalStmt);
+  sqlite3_finalize(pExtData->pSelectSiteIdOrdinalStmt);
   crsql_freeAllTableInfos(pExtData->zpTableInfos, pExtData->tableInfosLen);
   crsql_clear_stmt_cache(pExtData);
   sqlite3_free(pExtData);
@@ -79,6 +83,7 @@ void crsql_finalize(crsql_ExtData *pExtData) {
   sqlite3_finalize(pExtData->pSetSyncBitStmt);
   sqlite3_finalize(pExtData->pClearSyncBitStmt);
   sqlite3_finalize(pExtData->pSetSiteIdOrdinalStmt);
+  sqlite3_finalize(pExtData->pSelectSiteIdOrdinalStmt);
   crsql_clear_stmt_cache(pExtData);
   pExtData->pDbVersionStmt = 0;
   pExtData->pPragmaSchemaVersionStmt = 0;
@@ -86,6 +91,7 @@ void crsql_finalize(crsql_ExtData *pExtData) {
   pExtData->pSetSyncBitStmt = 0;
   pExtData->pClearSyncBitStmt = 0;
   pExtData->pSetSiteIdOrdinalStmt = 0;
+  pExtData->pSelectSiteIdOrdinalStmt = 0;
 }
 
 #define DB_VERSION_SCHEMA_VERSION 0

--- a/core/src/ext-data.h
+++ b/core/src/ext-data.h
@@ -38,6 +38,7 @@ struct crsql_ExtData {
   sqlite3_stmt *pSetSyncBitStmt;
   sqlite3_stmt *pClearSyncBitStmt;
   sqlite3_stmt *pSetSiteIdOrdinalStmt;
+  sqlite3_stmt *pSelectSiteIdOrdinalStmt;
   void *pStmtCache;
 };
 

--- a/py/correctness/tests/test_site_id_lookaside.py
+++ b/py/correctness/tests/test_site_id_lookaside.py
@@ -61,3 +61,7 @@ def test_local_changes_have_null_site():
     assert (a.execute(
         "SELECT count(*) FROM crsql_changes").fetchone()[0] == 4)
     None
+
+
+def test_site_id_ordinals_do_not_move_on_merge():
+    None

--- a/py/correctness/tests/test_site_id_lookaside.py
+++ b/py/correctness/tests/test_site_id_lookaside.py
@@ -64,4 +64,37 @@ def test_local_changes_have_null_site():
 
 
 def test_site_id_ordinals_do_not_move_on_merge():
+    a = make_simple_schema()
+
+    a.execute(
+        "INSERT INTO crsql_changes VALUES ('foo', x'010901', 'b', 1, 1, 1, x'1dc8d6bb7f8941088327d9439a7927a4', 1)")
+    a.commit()
+
+    x = a.execute("SELECT quote(site_id) FROM crsql_changes").fetchall()
+    assert (x == [("X'1DC8D6BB7F8941088327D9439A7927A4'",)])
+
+    # insert again with the same site id
+    a.execute(
+        "INSERT INTO crsql_changes VALUES ('foo', x'010902', 'b', 1, 1, 1, x'1dc8d6bb7f8941088327d9439a7927a4', 1)")
+    a.commit()
+
+    x = a.execute("SELECT quote(site_id) FROM crsql_changes").fetchall()
+    # site ids should be returned with changes
+    assert (x == [("X'1DC8D6BB7F8941088327D9439A7927A4'",),
+                  ("X'1DC8D6BB7F8941088327D9439A7927A4'",)])
+
+    # insert a new site id
+    a.execute(
+        "INSERT INTO crsql_changes VALUES ('foo', x'010903', 'b', 1, 1, 1, x'2dc8d6bb7f8941088327d9439a7927a4', 1)")
+    a.commit()
+    # insert again with that new site id
+    a.execute(
+        "INSERT INTO crsql_changes VALUES ('foo', x'010904', 'b', 1, 1, 1, x'2dc8d6bb7f8941088327d9439a7927a4', 1)")
+    a.commit()
+    # should only be 2 site ids w/ ordinals 1 and 2. 1DC... -> 1, 2DC... -> 2
+    x = a.execute(
+        "SELECT quote(site_id), ordinal FROM crsql_site_id WHERE ordinal != 0").fetchall()
+    assert (x == [("X'1DC8D6BB7F8941088327D9439A7927A4'", 1),
+                  ("X'2DC8D6BB7F8941088327D9439A7927A4'", 2)])
+
     None


### PR DESCRIPTION
need to implement the new test in py/correctness/tests/test_site_id_lookaside.py