### PR TITLE
Android build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -154,6 +154,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Rust Nightly
+        run: |
+          rustup toolchain install nightly-2023-06-17
+          rustup target add aarch64-linux-android --toolchain nightly-2023-06-17
+
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -138,3 +138,40 @@ jobs:
           file: core/dist/${{ matrix.artifact_name }}
           asset_name: ${{ matrix.asset_name }}
           tag: ${{ github.ref }}
+
+  prebuild-android:
+    name: Prebuild for android
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: crsqlite-aarch64-linux-android.so
+            asset_name: crsqlite-aarch64-linux-android.so
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r25c
+          local-cache: true
+          add-to-path: false
+
+      - name: Build
+        env:
+          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
+        run: |
+          cd core
+          make loadable
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: core/dist/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.asset_name }}
+          tag: ${{ github.ref }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -146,7 +146,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            artifact_name: crsqlite-aarch64-linux-android.so
+            artifact_name: crsqlite.so
             asset_name: crsqlite-aarch64-linux-android.so
 
     steps:

--- a/core/Makefile
+++ b/core/Makefile
@@ -38,6 +38,18 @@ rs_build_flags = -Zbuild-std
 		endif
 endif
 
+# aarch64-linux-android
+# https://github.com/marketplace/actions/setup-android-ndk
+ifdef ANDROID_TARGET
+CI_MAYBE_TARGET=$(ANDROID_TARGET)
+NDK = $(ANDROID_NDK_HOME) # ANDROID_NDK_HOME is an env variable
+NDK_HOSTARCH = linux-x86_64
+CC     			 = $(NDK)/toolchains/llvm/prebuilt/$(NDK_HOSTARCH)/bin/clang
+
+rs_build_flags = -Zbuild-std
+sysroot_option = --sysroot=$(NDK)/toolchains/llvm/prebuilt/$(NDK_HOSTARCH)/sysroot
+endif
+
 prefix=./dist
 dbg_prefix=./dbg
 


### PR DESCRIPTION
You can reproduce this build locally via:

```
cd core
export ANDROID_NDK_HOME=/path/to/your/ndk
export ANDROID_TARGET=aarch64-linux-anrdoid; make
```

The NDK can be downloaded from here: https://developer.android.com/ndk/downloads

This build works by:
1. Swapping out `clang` with the NDK version of clang: `CC = $(NDK)/toolchains/llvm/prebuilt/$(NDK_HOSTARCH)/bin/clang`
2. Setting the `sysroot`: `--sysroot=$(NDK)/toolchains/llvm/prebuilt/$(NDK_HOSTARCH)/sysroot`


Looks like the NDK paths are dependent on the host architecture

`NDK_HOSTARCH = linux-x86_64` (https://github.com/vlcn-io/cr-sqlite/pull/327/files#diff-d486e601a844f08eaa052d963bedbdd8a7db76d664a5f44fe34bf4fd6db1064aR46-R47)

so to reproduce the build locally you'll need to set your host architecture to the correct one for your machine.

The NDK didn't seem to have any host architectures that I do so I wasn't able to test locally but the github action succeeded (https://github.com/vlcn-io/cr-sqlite/actions/runs/5905000815/job/16018226391). Maybe I'll set up a `linux-x86_64` vm sometime...