### PR TITLE
Fix a bug in the fractional indexing implementation when a column type is specified

### DIFF
--- a/core/rs/fractindex-core/src/as_ordered.rs
+++ b/core/rs/fractindex-core/src/as_ordered.rs
@@ -118,8 +118,8 @@ fn create_pend_trigger(
 ) -> Result<ResultCode, ResultCode> {
     let trigger = format!(
         "CREATE TRIGGER IF NOT EXISTS \"__crsql_{table}_fractindex_pend_trig\" AFTER INSERT ON \"{table}\"
-        WHEN NEW.\"{order_by_column}\" = -1 OR NEW.\"{order_by_column}\" = 1 BEGIN
-            UPDATE \"{table}\" SET \"{order_by_column}\" = CASE NEW.\"{order_by_column}\"
+        WHEN CAST(NEW.\"{order_by_column}\" AS INTEGER) = -1 OR CAST(NEW.\"{order_by_column}\" AS INTEGER) = 1 BEGIN
+            UPDATE \"{table}\" SET \"{order_by_column}\" = CASE CAST(NEW.\"{order_by_column}\" AS INTEGER)
             WHEN -1 THEN crsql_fract_key_between(NULL, ({min_select}))
             WHEN 1 THEN crsql_fract_key_between(({max_select}), NULL)
             END

--- a/py/correctness/tests/test_as_ordered.py
+++ b/py/correctness/tests/test_as_ordered.py
@@ -2,33 +2,89 @@ from crsql_correctness import connect, close, min_db_v
 from pprint import pprint
 
 
-def test_first_insertion_start():
-    None
+def make_simple_schema():
+    c = connect(":memory:")
+    # O... so the type must be `ANY` for the orderable column for our triggers and the like to work...
+    # we could cast the whatever to an int...
+    c.execute("CREATE TABLE foo (a INTEGER PRIMARY KEY, spot TEXT, list)")
+    c.execute("SELECT crsql_as_crr('foo')")
+    c.execute("SELECT crsql_fract_as_ordered('foo', 'spot', 'list')")
+    c.commit()
+    return c
 
 
-def test_first_insertion_end():
-    None
+def test_first_insertion_prepend():
+    c = make_simple_schema()
+    c.execute("INSERT INTO foo VALUES (1, -1, 'a')")
+    c.commit()
+
+    rows = c.execute("SELECT * FROM foo").fetchall()
+    assert (rows == [(1, 'a0', 'a')])
+
+
+def test_first_insertion_append():
+    c = make_simple_schema()
+    c.execute("INSERT INTO foo VALUES (1, 1, 'a')")
+    c.commit()
+
+    rows = c.execute("SELECT * FROM foo").fetchall()
+    assert (rows == [(1, 'a0', 'a')])
 
 
 def test_middle_insertion():
-    None
+    c = make_simple_schema()
+    c.execute("INSERT INTO foo VALUES (1, -1, 'list')")
+    c.execute("INSERT INTO foo VALUES (3, 1, 'list')")
+    c.execute("INSERT INTO foo_fractindex (a, list, after_a) VALUES (2, 'list', 1)")
+    c.commit()
+
+    rows = c.execute("SELECT * FROM foo ORDER BY spot ASC").fetchall()
+    assert (rows == [(1, 'a0', 'list'), (2, 'a0V', 'list'), (3, 'a1', 'list')])
 
 
-def test_fron_insertion():
-    None
+def test_front_insertion():
+    c = make_simple_schema()
+    c.execute("INSERT INTO foo VALUES (2, -1, 'list')")
+    c.execute("INSERT INTO foo VALUES (3, 1, 'list')")
+    c.execute(
+        "INSERT INTO foo_fractindex (a, list, after_a) VALUES (1, 'list', NULL)")
+    c.commit()
+
+    rows = c.execute("SELECT * FROM foo ORDER BY spot ASC").fetchall()
+    assert ([(1, 'Zz', 'list'), (2, 'a0', 'list'), (3, 'a1', 'list')] == rows)
 
 
 def test_endinsertion():
-    None
+    c = make_simple_schema()
+    c.execute("INSERT INTO foo VALUES (1, -1, 'list')")
+    c.execute("INSERT INTO foo VALUES (2, 1, 'list')")
+    c.execute(
+        "INSERT INTO foo_fractindex (a, list, after_a) VALUES (3, 'list', 2)")
+    c.commit()
+
+    rows = c.execute("SELECT * FROM foo ORDER BY spot ASC").fetchall()
+    assert (rows == [(1, 'a0', 'list'), (2, 'a1', 'list'), (3, 'a2', 'list')])
 
 
-def test_view_clean_insert():
-    None
+def test_view_first_insertion():
+    c = make_simple_schema()
+    c.execute(
+        "INSERT INTO foo_fractindex (a, list, after_a) VALUES (1, 'list', NULL)")
+    c.commit()
 
-
-def test_view_after_insert():
-    None
+    rows = c.execute("SELECT * FROM foo").fetchall()
+    assert (rows == [(1, 'a0', 'list')])
 
 
 def test_view_move():
-    None
+    c = make_simple_schema()
+    c.execute("INSERT INTO foo VALUES (1, 1, 'list')")
+    c.execute("INSERT INTO foo VALUES (2, 1, 'list')")
+    c.execute("INSERT INTO foo VALUES (3, 1, 'list')")
+    c.commit()
+
+    # move 3 to be after 1
+    c.execute("UPDATE foo_fractindex SET after_a = 1 WHERE a = 3")
+    c.commit()
+    rows = c.execute("SELECT * FROM foo ORDER BY spot ASC").fetchall()
+    assert (rows == [(1, 'a0', 'list'), (3, 'a0V', 'list'), (2, 'a1', 'list')])

--- a/py/correctness/tests/test_as_ordered.py
+++ b/py/correctness/tests/test_as_ordered.py
@@ -1,0 +1,34 @@
+from crsql_correctness import connect, close, min_db_v
+from pprint import pprint
+
+
+def test_first_insertion_start():
+    None
+
+
+def test_first_insertion_end():
+    None
+
+
+def test_middle_insertion():
+    None
+
+
+def test_fron_insertion():
+    None
+
+
+def test_endinsertion():
+    None
+
+
+def test_view_clean_insert():
+    None
+
+
+def test_view_after_insert():
+    None
+
+
+def test_view_move():
+    None


### PR DESCRIPTION
`crsql_as_ordered` would fail if the table schema specified a type for the column used to order by.

E.g.,

```sql
CREATE TABLE test (id, spot TEXT, list TEXT);
```

Assigning `TEXT` to `spot` would cause inserts to spot to be treated as text. This meant out `-1` and `1` shorthand for pre-pend and append would fail to compare and write an invalid fractional index. Fix that by casting the `ordering` column before using it.