### PR TITLE
Migrate to base 95 fractional indexing

### DIFF
--- a/core/src/rs-fract.test.c
+++ b/core/src/rs-fract.test.c
@@ -43,7 +43,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   const unsigned char *order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a0") == 0);
+  assert(strcmp((const char *)order, "a ") == 0);
   sqlite3_finalize(pStmt);
 
   // test append
@@ -55,7 +55,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a1") == 0);
+  assert(strcmp((const char *)order, "a!") == 0);
   sqlite3_finalize(pStmt);
 
   // test insert after head
@@ -71,7 +71,7 @@ static void testAsOrdered() {
   while (sqlite3_step(pStmt) == SQLITE_ROW) {
     assert(sqlite3_column_int(pStmt, 0) == i);
     if (i == 2) {
-      assert(strcmp((const char *)sqlite3_column_text(pStmt, 1), "a0V") == 0);
+      assert(strcmp((const char *)sqlite3_column_text(pStmt, 1), "a P") == 0);
     }
     i += 1;
   }
@@ -88,7 +88,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "Zz") == 0);
+  assert(strcmp((const char *)order, "Z~") == 0);
   sqlite3_finalize(pStmt);
 
   // append to a list with items via 1 trick
@@ -102,7 +102,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a2") == 0);
+  assert(strcmp((const char *)order, "a\"") == 0);
   sqlite3_finalize(pStmt);
 
   // before head via view and null
@@ -116,7 +116,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "Zy") == 0);
+  assert(strcmp((const char *)order, "Z}") == 0);
   sqlite3_finalize(pStmt);
 
   // after tail view view
@@ -130,7 +130,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a3") == 0);
+  assert(strcmp((const char *)order, "a#") == 0);
   sqlite3_finalize(pStmt);
 
   // test move after
@@ -142,17 +142,17 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a2V") == 0);
+  assert(strcmp((const char *)order, "a\"P") == 0);
   sqlite3_finalize(pStmt);
 
   /*
-  -1 -> Zy
-  0 -> Zz
-  1 -> a0
+  -1 -> Z}
+  0 -> Z~
+  1 -> a
   2 -> ?
-  4 -> a2
-  3 -> a2V
-  5 -> a3
+  4 -> a"
+  3 -> a"P
+  5 -> a#
   */
 
   // insert between / insert after
@@ -166,17 +166,17 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a0V") == 0);
+  assert(strcmp((const char *)order, "a P") == 0);
   sqlite3_finalize(pStmt);
 
   /*
-  -1 -> Zy
-  0 -> Zz
-  1 -> a0
-  2 -> a0V
-  4 -> a2
-  3 -> a2V
-  5 -> a3
+  -1 -> Z}
+  0 -> Z~
+  1 -> a
+  2 -> a P
+  4 -> a"
+  3 -> a"P
+  5 -> a#
   */
 
   // move before
@@ -189,24 +189,24 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a1") == 0);
+  assert(strcmp((const char *)order, "a!") == 0);
   sqlite3_finalize(pStmt);
 
   /*
-  -1 -> Zy
-  0 -> Zz
-  1 -> a0
-  2 -> a0V
-  3 -> a1
-  4 -> a2
-  5 -> a3
+  -1 -> Z}
+  0 -> Z~
+  1 -> a
+  2 -> a P
+  3 -> a!
+  4 -> a"
+  5 -> a#
   */
 
   // make some collisions
   rc = sqlite3_exec(
       db,
       "INSERT INTO todo (id, list_id, content, complete, ordering) "
-      "VALUES (6, 1, 'xx', false, 'a1')",
+      "VALUES (6, 1, 'xx', false, 'a!')",
       0, 0, 0);
   assert(rc == SQLITE_OK);
   // 3 & 6 collide, try insertion after 3
@@ -222,7 +222,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a0t") == 0);
+  assert(strcmp((const char *)order, "a t") == 0);
   sqlite3_finalize(pStmt);
 
   rc += sqlite3_prepare_v2(db, "SELECT ordering FROM todo WHERE id = 3", -1,
@@ -230,7 +230,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a0l") == 0);
+  assert(strcmp((const char *)order, "a h") == 0);
   sqlite3_finalize(pStmt);
 
   rc += sqlite3_prepare_v2(db, "SELECT ordering FROM todo WHERE id = 6", -1,
@@ -238,7 +238,7 @@ static void testAsOrdered() {
   assert(rc == SQLITE_OK);
   sqlite3_step(pStmt);
   order = sqlite3_column_text(pStmt, 0);
-  assert(strcmp((const char *)order, "a1") == 0);
+  assert(strcmp((const char *)order, "a!") == 0);
   sqlite3_finalize(pStmt);
 
   // Test many list column

--- a/py/correctness/tests/test_as_ordered.py
+++ b/py/correctness/tests/test_as_ordered.py
@@ -19,7 +19,7 @@ def test_first_insertion_prepend():
     c.commit()
 
     rows = c.execute("SELECT * FROM foo").fetchall()
-    assert (rows == [(1, 'a0', 'a')])
+    assert (rows == [(1, 'a ', 'a')])
 
 
 def test_first_insertion_append():
@@ -28,7 +28,7 @@ def test_first_insertion_append():
     c.commit()
 
     rows = c.execute("SELECT * FROM foo").fetchall()
-    assert (rows == [(1, 'a0', 'a')])
+    assert (rows == [(1, 'a ', 'a')])
 
 
 def test_middle_insertion():
@@ -39,7 +39,7 @@ def test_middle_insertion():
     c.commit()
 
     rows = c.execute("SELECT * FROM foo ORDER BY spot ASC").fetchall()
-    assert (rows == [(1, 'a0', 'list'), (2, 'a0V', 'list'), (3, 'a1', 'list')])
+    assert (rows == [(1, 'a ', 'list'), (2, 'a P', 'list'), (3, 'a!', 'list')])
 
 
 def test_front_insertion():
@@ -51,7 +51,7 @@ def test_front_insertion():
     c.commit()
 
     rows = c.execute("SELECT * FROM foo ORDER BY spot ASC").fetchall()
-    assert ([(1, 'Zz', 'list'), (2, 'a0', 'list'), (3, 'a1', 'list')] == rows)
+    assert ([(1, 'Z~', 'list'), (2, 'a ', 'list'), (3, 'a!', 'list')] == rows)
 
 
 def test_endinsertion():
@@ -63,7 +63,7 @@ def test_endinsertion():
     c.commit()
 
     rows = c.execute("SELECT * FROM foo ORDER BY spot ASC").fetchall()
-    assert (rows == [(1, 'a0', 'list'), (2, 'a1', 'list'), (3, 'a2', 'list')])
+    assert (rows == [(1, 'a ', 'list'), (2, 'a!', 'list'), (3, 'a"', 'list')])
 
 
 def test_view_first_insertion():
@@ -73,7 +73,7 @@ def test_view_first_insertion():
     c.commit()
 
     rows = c.execute("SELECT * FROM foo").fetchall()
-    assert (rows == [(1, 'a0', 'list')])
+    assert (rows == [(1, 'a ', 'list')])
 
 
 def test_view_move():
@@ -87,4 +87,4 @@ def test_view_move():
     c.execute("UPDATE foo_fractindex SET after_a = 1 WHERE a = 3")
     c.commit()
     rows = c.execute("SELECT * FROM foo ORDER BY spot ASC").fetchall()
-    assert (rows == [(1, 'a0', 'list'), (3, 'a0V', 'list'), (2, 'a1', 'list')])
+    assert (rows == [(1, 'a ', 'list'), (3, 'a P', 'list'), (2, 'a!', 'list')])


### PR DESCRIPTION
Closes https://github.com/vlcn-io/cr-sqlite/issues/179.

Fractional indexing now uses base 95 for more efficiency. All the tests were updated accordingly.