### PR TITLE
fiddle with i686 / win32 builds on osx

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -30,6 +30,15 @@ ifdef CONFIG_WINDOWS
 LOADABLE_EXTENSION=dll
 endif
 
+ifeq ($(CI_MAYBE_TARGET),i686-pc-windows-gnu)
+# -fPIC not available for this target??
+# LOADABLE_CFLAGS=-std=c99 -shared -Wall
+CC=i686-w64-mingw32-gcc
+C_TARGET=
+LOADABLE_EXTENSION=i686.dll
+endif
+
+rs_build_flags = -Zbuild-std
 ifdef IOS_TARGET
 CI_MAYBE_TARGET=$(IOS_TARGET)
 rs_build_flags = -Zbuild-std


### PR DESCRIPTION
- brew install mingw-w64
- /opt/homebrew/Cellar has i686-w64-mingw32-gcc and other compilers