### PR TITLE
fix db version signature

### DIFF
--- a/core/src/rust.h
+++ b/core/src/rust.h
@@ -25,6 +25,6 @@ int crsql_ensure_table_infos_are_up_to_date(sqlite3 *db,
                                             char **err);
 int crsql_fill_db_version_if_needed(sqlite3 *db, crsql_ExtData *pExtData,
                                     char **errmsg);
-int crsql_next_db_version(sqlite3 *db, crsql_ExtData *pExtData,
-                          sqlite3_int64 mergingVersion, char **errmsg);
+sqlite_int64 crsql_next_db_version(sqlite3 *db, crsql_ExtData *pExtData,
+                                   sqlite3_int64 mergingVersion, char **errmsg);
 #endif


### PR DESCRIPTION
I typoed this when porting to Rust. Should be `sqlite_int64` in `rust.h` not `int`

This typo fatals the WASM builds