### PR TITLE
use db_version for col_version

### DIFF
--- a/core/rs/core/src/tableinfo.rs
+++ b/core/rs/core/src/tableinfo.rs
@@ -507,7 +507,7 @@ impl TableInfo {
               ?,
               0 WHERE true
             ON CONFLICT DO UPDATE SET
-              col_version = col_version + 1,
+              col_version = crsql_next_db_version(),
               db_version = ?,
               seq = ?,
               site_id = 0;",

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -2,4 +2,4 @@
 
 # source env/bin/activate
 # python -m pytest tests -s -k test_cl_merging
-python3 -m pytest tests -s
+python3 -m pytest tests -s 

--- a/py/correctness/tests/test_cl_merging.py
+++ b/py/correctness/tests/test_cl_merging.py
@@ -105,7 +105,9 @@ def test_larger_cl_wins_all():
     c1.commit()
 
     c2.execute("INSERT INTO foo VALUES (1, 1)")
+    c2.commit()
     c2.execute("UPDATE foo SET b = 3 WHERE a = 1")
+    c2.commit()
     c2.execute("UPDATE foo SET b = 4 WHERE a = 1")
     c2.commit()
 
@@ -118,7 +120,7 @@ def test_larger_cl_wins_all():
     assert (c1.execute(
         "SELECT col_version, cl FROM crsql_changes WHERE cid = 'b'").fetchone() == (1, 3))
 
-    # c2 hard col_version = 3 given insert + 2 updates
+    # c2 had col_version = 3 given insert + 2 updates
     # an cl = 1 given a single isnert
     assert (c2.execute(
         "SELECT col_version, cl FROM crsql_changes WHERE cid = 'b'").fetchone() == (3, 1))
@@ -996,15 +998,15 @@ def test_discord_report_corrosion():
     # make sure we have the expected change coming out of node C
     assert (c.execute(
         "SELECT cid, col_version, cl FROM crsql_changes WHERE db_version = 4").fetchall() ==
-        [('b', 2, 3), ('c', 2, 3)])
+        [('b', 4, 3), ('c', 4, 3)])
 
     # a received the delete followed by updates of cells `b` and `c`
     # so it's changes should only have:
     # 1. the sentinal with causal length 3
-    # 2. cell b with col version 2 and causal length 3
+    # 2. cell b with col version 4 and causal length 3
     # 3. cell c with the same
     assert (a.execute("SELECT cid, col_version, cl FROM crsql_changes").fetchall(
-    ) == [('-1', 3, 3), ('b', 2, 3), ('c', 2, 3)])
+    ) == [('-1', 3, 3), ('b', 4, 3), ('c', 4, 3)])
 
     # now that old re-insert goes to A
     sync_left_to_right_single_vrsn(c, a, 3)


### PR DESCRIPTION
This ensures that if two fields should always change together that they always will as when one loses a merge the other one will also lose the merge.

Hmm, except in the case where the clocks are equal and then we tie break on value. Would be better to tie break on peer id for consistency.