### PR TITLE
Make site_id required

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ The full documentation site is available [here](https://vlcn.io/docs).
 - A function extension (`crsql_as_crr`) to upgrade existing tables to "crrs" or "conflict free replicated relations"
   - `SELECT crsql_as_crr('table_name')`
 - A virtual table (`crsql_changes`) to ask the database for changesets or to apply changesets from another database
-  - `SELECT "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_site_id()), cl, seq FROM crsql_changes WHERE db_version > x AND site_id IS NULL` -- to get local changes
-  - `SELECT "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_site_id()), cl, seq FROM crsql_changes WHERE db_version > x AND site_id IS NOT some_site` -- to get all changes excluding those synced from some site
+  - `SELECT "table", "pk", "cid", "val", "col_version", "db_version", "site_id", cl, seq FROM crsql_changes WHERE db_version > x AND site_id IS NULL` -- to get local changes
+  - `SELECT "table", "pk", "cid", "val", "col_version", "db_version", "site_id", cl, seq FROM crsql_changes WHERE db_version > x AND site_id IS NOT some_site` -- to get all changes excluding those synced from some site
   - `INSERT INTO crsql_changes VALUES ([patches received from select on another peer])`
 - And `crsql_begin_alter('table_name')` & `crsql_alter_commit('table_name')` primitives to allow altering table definitions that have been upgraded to `crr`s.
   - Until we move forward with extending the syntax of SQLite to be CRR aware, altering CRRs looks like:
@@ -104,10 +104,10 @@ insert into foo (a,b) values (1,2);
 insert into baz (a,b,c,d) values ('a', 'woo', 'doo', 'daa');
 
 -- ask for a record of what has changed
-select "table", "pk", "cid", "val", "col_version", "db_version", COALESCE("site_id", crsql_site_id()), "cl", "seq" from crsql_changes;
+select "table", "pk", "cid", "val", "col_version", "db_version", "site_id", "cl", "seq" from crsql_changes;
 
 ┌───────┬─────────────┬─────┬───────┬─────────────┬────────────┬──────────────────────────────────────┬────┬─────┐
-│ table │     pk      │ cid │  val  │ col_version │ db_version │ COALESCE("site_id", crsql_site_id()) │ cl │ seq │
+│ table │     pk      │ cid │  val  │ col_version │ db_version │ "site_id" │ cl │ seq │
 ├───────┼─────────────┼─────┼───────┼─────────────┼────────────┼──────────────────────────────────────┼────┼─────┤
 │ 'foo' │ x'010901'   │ 'b' │ 2     │ 1           │ 1          │ x'049c48eadf4440d7944ed9ec88b13ea5'  │ 1  │ 0   │
 │ 'baz' │ x'010b0161' │ 'b' │ 'woo' │ 1           │ 2          │ x'049c48eadf4440d7944ed9ec88b13ea5'  │ 1  │ 0   │

--- a/core/rs/bundle_static/Cargo.lock
+++ b/core/rs/bundle_static/Cargo.lock
@@ -19,31 +19,26 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.63.0"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn",
  "which",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -237,7 +232,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -260,6 +255,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -320,7 +325,7 @@ version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -355,17 +360,6 @@ dependencies = [
  "num-traits",
  "sqlite3_allocator",
  "sqlite3_capi",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]

--- a/core/rs/core/src/bootstrap.rs
+++ b/core/rs/core/src/bootstrap.rs
@@ -209,7 +209,7 @@ pub fn create_clock_table(
       site_id INTEGER,
       seq INTEGER NOT NULL,
       PRIMARY KEY (key, col_name)
-    ) WITHOUT ROWID",
+    ) WITHOUT ROWID, STRICT",
         table_name = crate::util::escape_ident(table_name),
     ))?;
 

--- a/core/rs/core/src/bootstrap.rs
+++ b/core/rs/core/src/bootstrap.rs
@@ -206,7 +206,7 @@ pub fn create_clock_table(
       col_name TEXT NOT NULL,
       col_version INTEGER NOT NULL,
       db_version INTEGER NOT NULL,
-      site_id INTEGER,
+      site_id INTEGER NOT NULL DEFAULT 0,
       seq INTEGER NOT NULL,
       PRIMARY KEY (key, col_name)
     ) WITHOUT ROWID, STRICT",

--- a/core/rs/core/src/tableinfo.rs
+++ b/core/rs/core/src/tableinfo.rs
@@ -421,12 +421,12 @@ impl TableInfo {
             2,
             ?,
             ?,
-            NULL WHERE true
+            0 WHERE true
           ON CONFLICT DO UPDATE SET
             col_version = 1 + col_version,
             db_version = ?,
             seq = ?,
-            site_id = crsql_site_id()",
+            site_id = 0",
                 table_name = crate::util::escape_ident(&self.tbl_name),
                 sentinel = crate::c::DELETE_SENTINEL,
             );
@@ -471,12 +471,12 @@ impl TableInfo {
                 1,
                 ?,
                 ?,
-                NULL WHERE true
+                0 WHERE true
                 ON CONFLICT DO UPDATE SET
                   col_version = CASE col_version % 2 WHEN 0 THEN col_version + 1 ELSE col_version + 2 END,
                   db_version = ?,
                   seq = ?,
-                  site_id = NULL",
+                  site_id = 0",
               table_name = crate::util::escape_ident(&self.tbl_name),
               sentinel = crate::c::INSERT_SENTINEL,
             );
@@ -505,12 +505,12 @@ impl TableInfo {
               1,
               ?,
               ?,
-              NULL WHERE true
+              0 WHERE true
             ON CONFLICT DO UPDATE SET
               col_version = col_version + 1,
               db_version = ?,
               seq = ?,
-              site_id = NULL;",
+              site_id = 0;",
                 table_name = crate::util::escape_ident(&self.tbl_name),
             );
             let ret = db.prepare_v3(&sql, sqlite::PREPARE_PERSISTENT)?;
@@ -533,7 +533,7 @@ impl TableInfo {
                 col_version = CASE col_version % 2 WHEN 0 THEN col_version + 1 ELSE col_version + 2 END,
                 db_version = ?,
                 seq = ?,
-                site_id = NULL
+                site_id = 0
               WHERE key = ? AND col_name = ?",
               table_name = crate::util::escape_ident(&self.tbl_name),
             );

--- a/core/rs/core/src/tableinfo.rs
+++ b/core/rs/core/src/tableinfo.rs
@@ -426,7 +426,7 @@ impl TableInfo {
             col_version = 1 + col_version,
             db_version = ?,
             seq = ?,
-            site_id = NULL",
+            site_id = crsql_site_id()",
                 table_name = crate::util::escape_ident(&self.tbl_name),
                 sentinel = crate::c::DELETE_SENTINEL,
             );

--- a/core/rs/integration_check/Cargo.lock
+++ b/core/rs/integration_check/Cargo.lock
@@ -19,31 +19,26 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.63.0"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn",
  "which",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -297,7 +292,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn",
 ]
 
 [[package]]
@@ -320,6 +315,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -380,7 +385,7 @@ version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -416,7 +421,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn",
 ]
 
 [[package]]
@@ -453,17 +458,6 @@ dependencies = [
  "num-traits",
  "sqlite3_allocator",
  "sqlite3_capi",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -516,7 +510,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.33",
+ "syn",
 ]
 
 [[package]]

--- a/core/src/changes-vtab.c
+++ b/core/src/changes-vtab.c
@@ -27,7 +27,7 @@ static int changesConnect(sqlite3 *db, void *pAux, int argc,
       db,
       "CREATE TABLE x([table] TEXT NOT NULL, [pk] BLOB NOT NULL, [cid] TEXT "
       "NOT NULL, [val] ANY, [col_version] INTEGER NOT NULL, [db_version] "
-      "INTEGER NOT NULL, [site_id] BLOB, [cl] INTEGER NOT NULL, [seq] "
+      "INTEGER NOT NULL, [site_id] BLOB NOT NULL, [cl] INTEGER NOT NULL, [seq] "
       "INTEGER NOT NULL)");
   if (rc != SQLITE_OK) {
     *pzErr = sqlite3_mprintf("Could not define the table");

--- a/core/src/changes-vtab.test.c
+++ b/core/src/changes-vtab.test.c
@@ -83,16 +83,16 @@ static void testFilters() {
 
   printf("is null\n");
   assertCount(db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NULL",
-              3);
+              0);
 
   printf("is not null\n");
   assertCount(
-      db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT NULL", 0);
+      db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT NULL", 3);
 
   printf("equals\n");
   assertCount(
       db, "SELECT count(*) FROM crsql_changes WHERE site_id = crsql_site_id()",
-      0);
+      3);
 
   // 0 rows is actually correct ANSI sql behavior. NULLs are never equal, or not
   // equal, to anything in ANSI SQL. So users must use `IS NOT` to check rather
@@ -105,10 +105,10 @@ static void testFilters() {
       0);
 
   printf("is not\n");
-  // All rows are currently null for site_id
+  // All rows are currently equal to site_id since all rows are currently local
+  // writes
   assertCount(
-      db,
-      "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT crsql_site_id()",
+      db, "SELECT count(*) FROM crsql_changes WHERE site_id IS crsql_site_id()",
       3);
 
   // compare on db_version _and_ site_id
@@ -123,7 +123,7 @@ static void testFilters() {
   printf("OR condition\n");
   assertCount(db,
               "SELECT count(*) FROM crsql_changes WHERE db_version > 2 OR "
-              "site_id IS NULL",
+              "site_id IS crsql_site_id()",
               3);
 
   // compare on pks, table name, other not perfectly supported columns

--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -234,11 +234,11 @@ static void teste2e() {
   printf("db3sid: %s\n", db3siteid);
   printf("tempsid: %s\n", tmpSiteid);
   // printf("tmp: %s, db3: %s", tmpSiteid, db3siteid);
-  assert(strcmp(tmpSiteid, db3siteid) == 0);
+  assert(strcmp(tmpSiteid, db1siteid) == 0);
 
   rc = sqlite3_step(pStmt3);
   assert(rc == SQLITE_ROW);
-  assert(strcmp((const char *)sqlite3_column_text(pStmt3, 0), db3siteid) == 0);
+  assert(strcmp((const char *)sqlite3_column_text(pStmt3, 0), db1siteid) == 0);
   sqlite3_finalize(pStmt3);
 
   rc = sqlite3_prepare_v2(db2, "SELECT * FROM foo ORDER BY a ASC", -1, &pStmt2,
@@ -576,9 +576,9 @@ static void testPullingOnlyLocalChanges() {
   // TODO: why does `IS NULL` not work in the vtab???
   // `IS NOT NULL` also fails to call the virtual table bestIndex function with
   // any constraints p pIdxInfo->nConstraint
-  sqlite3_prepare_v2(db,
-                     "SELECT count(*) FROM crsql_changes WHERE site_id IS NULL",
-                     -1, &pStmt, 0);
+  sqlite3_prepare_v2(
+      db, "SELECT count(*) FROM crsql_changes WHERE site_id IS crsql_site_id()",
+      -1, &pStmt, 0);
 
   rc = sqlite3_step(pStmt);
   assert(rc == SQLITE_ROW);
@@ -591,8 +591,9 @@ static void testPullingOnlyLocalChanges() {
   sqlite3_finalize(pStmt);
 
   sqlite3_prepare_v2(
-      db, "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT NULL", -1,
-      &pStmt, 0);
+      db,
+      "SELECT count(*) FROM crsql_changes WHERE site_id IS NOT crsql_site_id()",
+      -1, &pStmt, 0);
   rc = sqlite3_step(pStmt);
   assert(rc == SQLITE_ROW);
   count = sqlite3_column_int(pStmt, 0);

--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -229,15 +229,16 @@ static void teste2e() {
   assert(rc == SQLITE_ROW);
 
   const char *tmpSiteid = (const char *)sqlite3_column_text(pStmt3, 0);
-  // printf("db1sid: %s\n", db1siteid);
-  // printf("db2sid: %s\n", db2siteid);
-  // printf("db3sid: %s\n", db3siteid);
-  // printf("tempsid: %s\n", tmpSiteid);
-  assert(strcmp(tmpSiteid, "NULL") == 0);
+  printf("db1sid: %s\n", db1siteid);
+  printf("db2sid: %s\n", db2siteid);
+  printf("db3sid: %s\n", db3siteid);
+  printf("tempsid: %s\n", tmpSiteid);
+  // printf("tmp: %s, db3: %s", tmpSiteid, db3siteid);
+  assert(strcmp(tmpSiteid, db3siteid) == 0);
 
   rc = sqlite3_step(pStmt3);
   assert(rc == SQLITE_ROW);
-  assert(strcmp((const char *)sqlite3_column_text(pStmt3, 0), "NULL") == 0);
+  assert(strcmp((const char *)sqlite3_column_text(pStmt3, 0), db3siteid) == 0);
   sqlite3_finalize(pStmt3);
 
   rc = sqlite3_prepare_v2(db2, "SELECT * FROM foo ORDER BY a ASC", -1, &pStmt2,

--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -229,11 +229,10 @@ static void teste2e() {
   assert(rc == SQLITE_ROW);
 
   const char *tmpSiteid = (const char *)sqlite3_column_text(pStmt3, 0);
-  printf("db1sid: %s\n", db1siteid);
-  printf("db2sid: %s\n", db2siteid);
-  printf("db3sid: %s\n", db3siteid);
-  printf("tempsid: %s\n", tmpSiteid);
-  // printf("tmp: %s, db3: %s", tmpSiteid, db3siteid);
+  // printf("db1sid: %s\n", db1siteid);
+  // printf("db2sid: %s\n", db2siteid);
+  // printf("db3sid: %s\n", db3siteid);
+  // printf("tempsid: %s\n", tmpSiteid);
   assert(strcmp(tmpSiteid, db1siteid) == 0);
 
   rc = sqlite3_step(pStmt3);

--- a/py/correctness/src/crsql_correctness/__init__.py
+++ b/py/correctness/src/crsql_correctness/__init__.py
@@ -15,4 +15,8 @@ def close(c):
     c.close()
 
 
+def get_site_id(c):
+    return c.execute("SELECT crsql_site_id()").fetchone()[0]
+
+
 min_db_v = 0

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -3,9 +3,3 @@
 # source env/bin/activate
 # python -m pytest tests -s -k test_cl_merging
 python3 -m pytest tests -s 
-
-# -k test_schema_modification
-# test_site_id_lookaside
-# test_sync
-
-# -k test_sync_prop.py

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -2,6 +2,10 @@
 
 # source env/bin/activate
 # python -m pytest tests -s -k test_cl_merging
-python3 -m pytest tests -s
+python3 -m pytest tests -s 
+
+# -k test_schema_modification
+# test_site_id_lookaside
+# test_sync
 
 # -k test_sync_prop.py

--- a/py/correctness/tests/test_cl_merging.py
+++ b/py/correctness/tests/test_cl_merging.py
@@ -214,7 +214,7 @@ def test_equivalent_delete_cls_is_noop():
     # create a manual clock entry that wouldn't normally exist
     # this clock entry would be removed if the merge does any work rather than bailing early
     c2.execute(
-        "INSERT INTO foo__crsql_clock VALUES (1, 'b', 3, 1, NULL, 1)")
+        "INSERT INTO foo__crsql_clock VALUES (1, 'b', 3, 1, 0, 1)")
     c2.commit()
     pre_changes = c2.execute("SELECT * FROM crsql_changes").fetchall()
     sync_left_to_right(c1, c2, 0)

--- a/py/correctness/tests/test_insert_new_rows.py
+++ b/py/correctness/tests/test_insert_new_rows.py
@@ -13,7 +13,7 @@ def test_c1_c2_c3_c4_c6_c7_crr_values():
 
     rows = c.execute(
         "select key, col_name, col_version, db_version, site_id from foo__crsql_clock").fetchall()
-    assert [(1, 'a', 1, init_version + 1, None)] == rows
+    assert [(1, 'a', 1, init_version + 1, 0)] == rows
     new_version = c.execute("SELECT crsql_db_version()").fetchone()[0]
 
     assert new_version == init_version + 1

--- a/py/correctness/tests/test_schema_modification.py
+++ b/py/correctness/tests/test_schema_modification.py
@@ -86,8 +86,8 @@ def test_drop_clock_on_col_remove():
     assert (changes == expected)
 
     clock_entries = c.execute(clock_query).fetchall()
-    assert (clock_entries == [(1, 1, 1, 'complete', None),
-            (1, 1, 1, 'list', None), (1, 1, 1, 'name', None)])
+    assert (clock_entries == [(1, 1, 1, 'complete', 0),
+            (1, 1, 1, 'list', 0), (1, 1, 1, 'name', 0)])
 
     c.execute("SELECT crsql_begin_alter('todo');")
     # Dropping a column should remove its entries from our replication logs.
@@ -105,7 +105,7 @@ def test_drop_clock_on_col_remove():
     clock_entries = c.execute(clock_query).fetchall()
     assert (
         clock_entries == [
-            (1, 1, 1, 'complete', None), (1, 1, 1, 'name', None)]
+            (1, 1, 1, 'complete', 0), (1, 1, 1, 'name', 0)]
     )
 
 
@@ -616,6 +616,7 @@ def test_add_new_col_to_pk():
     c.execute("SELECT crsql_commit_alter('foo');")
 
     changes = c.execute(full_changes_query).fetchall()
+    pprint(changes)
     assert (changes == [('foo', b'\x02\t\x01\t\x03', 'b', 2, 1, 1, None),
                         ('foo', b'\x02\t\x04\t\x06', 'b', 5, 1, 1, None)])
 

--- a/py/correctness/tests/test_site_id_lookaside.py
+++ b/py/correctness/tests/test_site_id_lookaside.py
@@ -46,7 +46,7 @@ def test_site_id_filter():
         "SELECT quote(site_id) FROM crsql_changes WHERE site_id = x'1dc8d6bb7f8941088327d9439a7927a4'").fetchone()[0] == "x'1dc8d6bb7f8941088327d9439a7927a4'".upper())
 
 
-def test_local_changes_have_null_site():
+def test_local_changes_have_local_site():
     a = make_simple_schema()
     a.execute("INSERT INTO foo VALUES (2,2)")
     a.execute("INSERT INTO foo VALUES (3,2)")
@@ -57,7 +57,7 @@ def test_local_changes_have_null_site():
     a.commit()
 
     assert (a.execute(
-        "SELECT count(*) FROM crsql_changes WHERE site_id IS NULL").fetchone()[0] == 3)
+        "SELECT count(*) FROM crsql_changes WHERE site_id IS crsql_site_id()").fetchone()[0] == 3)
     assert (a.execute(
         "SELECT count(*) FROM crsql_changes").fetchone()[0] == 4)
     None

--- a/py/correctness/tests/test_siteid.py
+++ b/py/correctness/tests/test_siteid.py
@@ -30,3 +30,11 @@ def test_c3c4():
     siteid_restored = c.execute("select crsql_site_id()").fetchone()[0]
 
     assert siteid_initial == siteid_restored
+
+
+def test_site_id_for_local_writes():
+    None
+
+
+def test_site_id_from_merge():
+    None

--- a/py/correctness/tests/test_siteid.py
+++ b/py/correctness/tests/test_siteid.py
@@ -1,6 +1,17 @@
 import pathlib
 from uuid import UUID
 from crsql_correctness import connect
+from pprint import pprint
+
+
+def sync_left_to_right(l, r, since):
+    r_site_id = r.execute("SELECT crsql_site_id()").fetchone()[0]
+    changes = l.execute(
+        "SELECT * FROM crsql_changes WHERE db_version > ? AND site_id IS NOT ?", (since, r_site_id))
+    for change in changes:
+        r.execute(
+            "INSERT INTO crsql_changes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", change)
+    r.commit()
 
 
 def test_c1():
@@ -32,9 +43,62 @@ def test_c3c4():
     assert siteid_initial == siteid_restored
 
 
+# Site id is set to crsql_site_id on local writes
 def test_site_id_for_local_writes():
-    None
+    c = connect(":memory:")
+    c.execute("CREATE TABLE foo (id not null, x, y, primary key (id))")
+    c.execute("SELECT crsql_as_crr('foo')")
+    c.commit()
+
+    c.execute("INSERT INTO foo VALUES (1, 2, 3)")
+    c.commit()
+
+    def check_counts():
+        total_changes_count = c.execute(
+            "SELECT count(*) FROM crsql_changes").fetchone()[0]
+        changes_with_local_site_count = c.execute(
+            "SELECT count(*) FROM crsql_changes WHERE site_id = crsql_site_id()").fetchone()[0]
+        assert total_changes_count == changes_with_local_site_count
+
+    c.execute("UPDATE foo SET x = 3 WHERE id = 1")
+    c.commit()
+    check_counts()
+
+    c.execute("INSERT OR REPLACE INTO foo VALUES (1, 5, 9)")
+    c.commit()
+    check_counts()
+
+    c.execute("DELETE FROM foo")
+    c.commit()
+    check_counts()
 
 
 def test_site_id_from_merge():
-    None
+    def simple_schema():
+        a = connect(":memory:")
+        a.execute("create table foo (a primary key not null, b);")
+        a.commit()
+        a.execute("SELECT crsql_as_crr('foo')")
+        a.commit()
+        return a
+
+    a = simple_schema()
+    a.execute("INSERT INTO foo VALUES (1, 2.0e2);")
+    a.commit()
+    a.execute("INSERT INTO foo VALUES (2, X'1232');")
+    a.commit()
+
+    b = simple_schema()
+    c = simple_schema()
+
+    sync_left_to_right(a, b, 0)
+    sync_left_to_right(b, c, 0)
+
+    site_ids_fromC = c.execute(
+        "SELECT site_id FROM crsql_changes ORDER BY pk ASC").fetchall()
+    site_ids_fromB = b.execute(
+        "SELECT site_id FROM crsql_changes ORDER BY pk ASC").fetchall()
+    site_ids_fromA = a.execute(
+        "SELECT site_id FROM crsql_changes ORDER BY pk ASC").fetchall()
+    assert site_ids_fromC == site_ids_fromA
+    assert site_ids_fromB == site_ids_fromA

--- a/py/correctness/tests/test_sync.py
+++ b/py/correctness/tests/test_sync.py
@@ -1,4 +1,4 @@
-from crsql_correctness import connect, close, min_db_v
+from crsql_correctness import connect, close, get_site_id
 import pprint
 
 # js_tests includes a Fast-Check driven merge test which is much more complete than what we have here
@@ -30,7 +30,8 @@ def create_schema(c):
     c.execute("CREATE TABLE \"user\" (id primary key not null, name)")
     c.execute("CREATE TABLE deck (id primary key not null, owner_id, title)")
     c.execute("CREATE TABLE slide (id primary key not null, deck_id, \"order\")")
-    c.execute("CREATE TABLE component (id primary key not null, type, slide_id, content)")
+    c.execute(
+        "CREATE TABLE component (id primary key not null, type, slide_id, content)")
 
     c.execute("select crsql_as_crr('user')")
     c.execute("select crsql_as_crr('deck')")
@@ -78,28 +79,29 @@ def apply_patches():
 def test_changes_since():
     dbs = init()
 
+    site_id = get_site_id(dbs[0])
     rows = get_changes_since(dbs[0], 0, "FF")
     # siteid = dbs[0].execute("select crsql_site_id()").fetchone()[0]
     siteid = None
     expected = [
-        ('user', b'\x01\t\x01', 'name', 'Javi', 1, 1, None, 1, 0),
-        ('deck', b'\x01\t\x01', 'owner_id', 1, 1, 1, None, 1, 1),
-        ('deck', b'\x01\t\x01', 'title', 'Preso', 1, 1, None, 1, 2),
-        ('slide', b'\x01\t\x01', 'deck_id', 1, 1, 1, None, 1, 3),
-        ('slide', b'\x01\t\x01', 'order', 0, 1, 1, None, 1, 4),
-        ('component', b'\x01\t\x01', 'type', 'text', 1, 1, None, 1, 5),
-        ('component', b'\x01\t\x01', 'slide_id', 1, 1, 1, None, 1, 6),
-        ('component', b'\x01\t\x01', 'content', 'wootwoot', 1, 1, None, 1, 7),
-        ('component', b'\x01\t\x02', 'type', 'text', 1, 1, None, 1, 8),
-        ('component', b'\x01\t\x02', 'slide_id', 1, 1, 1, None, 1, 9),
-        ('component', b'\x01\t\x02', 'content', 'toottoot', 1, 1, None, 1, 10),
-        ('component', b'\x01\t\x03', 'type', 'text', 1, 1, None, 1, 11),
-        ('component', b'\x01\t\x03', 'slide_id', 1, 1, 1, None, 1, 12),
-        ('component', b'\x01\t\x03', 'content', 'footfoot', 1, 1, None, 1, 13),
-        ('slide', b'\x01\t\x02', 'deck_id', 1, 1, 1, None, 1, 14),
-        ('slide', b'\x01\t\x02', 'order', 1, 1, 1, None, 1, 15),
-        ('slide', b'\x01\t\x03', 'deck_id', 1, 1, 1, None, 1, 16),
-        ('slide', b'\x01\t\x03', 'order', 2, 1, 1, None, 1, 17)
+        ('user', b'\x01\t\x01', 'name', 'Javi', 1, 1, site_id, 1, 0),
+        ('deck', b'\x01\t\x01', 'owner_id', 1, 1, 1, site_id, 1, 1),
+        ('deck', b'\x01\t\x01', 'title', 'Preso', 1, 1, site_id, 1, 2),
+        ('slide', b'\x01\t\x01', 'deck_id', 1, 1, 1, site_id, 1, 3),
+        ('slide', b'\x01\t\x01', 'order', 0, 1, 1, site_id, 1, 4),
+        ('component', b'\x01\t\x01', 'type', 'text', 1, 1, site_id, 1, 5),
+        ('component', b'\x01\t\x01', 'slide_id', 1, 1, 1, site_id, 1, 6),
+        ('component', b'\x01\t\x01', 'content', 'wootwoot', 1, 1, site_id, 1, 7),
+        ('component', b'\x01\t\x02', 'type', 'text', 1, 1, site_id, 1, 8),
+        ('component', b'\x01\t\x02', 'slide_id', 1, 1, 1, site_id, 1, 9),
+        ('component', b'\x01\t\x02', 'content', 'toottoot', 1, 1, site_id, 1, 10),
+        ('component', b'\x01\t\x03', 'type', 'text', 1, 1, site_id, 1, 11),
+        ('component', b'\x01\t\x03', 'slide_id', 1, 1, 1, site_id, 1, 12),
+        ('component', b'\x01\t\x03', 'content', 'footfoot', 1, 1, site_id, 1, 13),
+        ('slide', b'\x01\t\x02', 'deck_id', 1, 1, 1, site_id, 1, 14),
+        ('slide', b'\x01\t\x02', 'order', 1, 1, 1, site_id, 1, 15),
+        ('slide', b'\x01\t\x03', 'deck_id', 1, 1, 1, site_id, 1, 16),
+        ('slide', b'\x01\t\x03', 'order', 2, 1, 1, site_id, 1, 17)
     ]
 
     assert (rows == expected)
@@ -108,8 +110,8 @@ def test_changes_since():
 
     rows = get_changes_since(dbs[0], 1, 'FF')
 
-    assert (rows == [('user', b'\x01\x09\x01', 'name', "Maestro", 2, 2, None, 1, 0),
-                     ('deck', b'\x01\x09\x01', 'title', "Presto", 2, 2, None, 1, 1)])
+    assert (rows == [('user', b'\x01\x09\x01', 'name', "Maestro", 2, 2, site_id, 1, 0),
+                     ('deck', b'\x01\x09\x01', 'title', "Presto", 2, 2, site_id, 1, 1)])
 
 
 def test_delete():
@@ -120,10 +122,11 @@ def test_delete():
     delete_data(db)
 
     rows = get_changes_since(db, 1, 'FF')
-    siteid = None
+
+    site_id = get_site_id(db)
     # Deletes are marked with a sentinel id
     assert (rows == [('component', b'\x01\x09\x01',
-            '-1', None, 2, 2, siteid, 2, 0)])
+            '-1', None, 2, 2, site_id, 2, 0)])
 
     db.execute("DELETE FROM component")
     db.execute("DELETE FROM deck")
@@ -132,17 +135,15 @@ def test_delete():
 
     rows = get_changes_since(db, 0, 'FF')
 
-    pprint.pprint(rows)
-
     # TODO: should deletes not get a proper version? Would be better for ordering and chunking replications
-    assert (rows == [('user', b'\x01\t\x01', 'name', 'Javi', 1, 1, None, 1, 0),
-                     ('component', b'\x01\t\x01', '-1', None, 2, 2, None, 2, 0),
-                     ('component', b'\x01\t\x02', '-1', None, 2, 3, None, 2, 0),
-                     ('component', b'\x01\t\x03', '-1', None, 2, 3, None, 2, 1),
-                     ('deck', b'\x01\t\x01', '-1', None, 2, 3, None, 2, 2),
-                     ('slide', b'\x01\t\x01', '-1', None, 2, 3, None, 2, 3),
-                     ('slide', b'\x01\t\x02', '-1', None, 2, 3, None, 2, 4),
-                     ('slide', b'\x01\t\x03', '-1', None, 2, 3, None, 2, 5)])
+    assert (rows == [('user', b'\x01\t\x01', 'name', 'Javi', 1, 1, site_id, 1, 0),
+                     ('component', b'\x01\t\x01', '-1', None, 2, 2, site_id, 2, 0),
+                     ('component', b'\x01\t\x02', '-1', None, 2, 3, site_id, 2, 0),
+                     ('component', b'\x01\t\x03', '-1', None, 2, 3, site_id, 2, 1),
+                     ('deck', b'\x01\t\x01', '-1', None, 2, 3, site_id, 2, 2),
+                     ('slide', b'\x01\t\x01', '-1', None, 2, 3, site_id, 2, 3),
+                     ('slide', b'\x01\t\x02', '-1', None, 2, 3, site_id, 2, 4),
+                     ('slide', b'\x01\t\x03', '-1', None, 2, 3, site_id, 2, 5)])
 
     # test insert
 
@@ -181,7 +182,8 @@ def test_merging_on_defaults():
     # db2 set b to 2 this should be the winner
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
     # w a db version change since a write happened
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 2, None, 1, 0)])
+    site_id = get_site_id(db2)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 2, site_id, 1, 0)])
 
     close(db1)
     close(db2)
@@ -194,7 +196,8 @@ def test_merging_on_defaults():
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # db1 into db2
     # db2 should still win w. no db version change since no write happened
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, None, 1, 0)])
+    site_id = get_site_id(db2)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, site_id, 1, 0)])
 
     # test merging from thing without records (db1) to thing with records (db2)
 
@@ -235,7 +238,8 @@ def test_merging_larger_backfilled_default():
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # db version is pushed since 4 wins the col_version tie
     # col version stays since 1 is the max of winner and loser.
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 4, 1, 2, None, 1, 0)])
+    site_id = get_site_id(db1)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 4, 1, 2, site_id, 1, 0)])
 
 
 def test_merging_larger():
@@ -267,13 +271,14 @@ def test_db_version_moves_as_expected_post_alter():
     db.commit()
 
     changes = db.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, None, 1, 0),
-                        ('foo', b'\x01\t\x02', 'b', 3, 1, 2, None, 1, 0),
-                        ('foo', b'\x01\t\x02', 'c', 4, 1, 2, None, 1, 1),
-                        ('foo', b'\x01\t\x03', 'b', 4, 1, 3, None, 1, 0),
-                        ('foo', b'\x01\t\x03', 'c', 5, 1, 3, None, 1, 1),
-                        ('foo', b'\x01\t\x04', 'b', 4, 1, 4, None, 1, 0),
-                        ('foo', b'\x01\t\x04', 'c', 5, 1, 4, None, 1, 1)])
+    site_id = get_site_id(db)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, site_id, 1, 0),
+                        ('foo', b'\x01\t\x02', 'b', 3, 1, 2, site_id, 1, 0),
+                        ('foo', b'\x01\t\x02', 'c', 4, 1, 2, site_id, 1, 1),
+                        ('foo', b'\x01\t\x03', 'b', 4, 1, 3, site_id, 1, 0),
+                        ('foo', b'\x01\t\x03', 'c', 5, 1, 3, site_id, 1, 1),
+                        ('foo', b'\x01\t\x04', 'b', 4, 1, 4, site_id, 1, 0),
+                        ('foo', b'\x01\t\x04', 'c', 5, 1, 4, site_id, 1, 1)])
 
 
 # DB1 has a row with no clock records (added during schema modification)
@@ -319,24 +324,28 @@ def test_merging_on_defaults2():
     sync_left_to_right(db2, db1, 0)
 
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 4, 1, 1, None, 1, 0),
-                        ('foo', b'\x01\t\x01', 'c', 3, 1, 2, None, 1, 1)])
+    site_id1 = get_site_id(db1)
+    site_id2 = get_site_id(db2)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 4, 1, 1, site_id1, 1, 0),
+                        ('foo', b'\x01\t\x01', 'c', 3, 1, 2, site_id2, 1, 1)])
 
     close(db1)
     close(db2)
 
     db1 = create_db1()
     db2 = create_db2()
+    site_id1 = get_site_id(db1)
+    site_id2 = get_site_id(db2)
 
     sync_left_to_right(db1, db2, 0)
 
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     assert (changes == [  # db2 c 3 wins given columns with no value after an alter
         # do no merging
-        ('foo', b'\x01\t\x01', 'c', 3, 1, 1, None, 1, 1),
+        ('foo', b'\x01\t\x01', 'c', 3, 1, 1, site_id2, 1, 1),
         # Move db version since b lost on db2.
         # b had the value 2 on db2.
-        ('foo', b'\x01\t\x01', 'b', 4, 1, 2, None, 1, 0)])
+        ('foo', b'\x01\t\x01', 'b', 4, 1, 2, site_id1, 1, 0)])
 
 
 def create_basic_db():
@@ -363,13 +372,15 @@ def test_merge_same():
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # all at base version
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, None, 1, 0)])
+    site_id = get_site_id(db2)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, site_id, 1, 0)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
     # all at base version
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, None, 1, 0)])
+    site_id = get_site_id(db2)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, site_id, 1, 0)])
 
 
 def test_merge_matching_clocks_lesser_value():
@@ -387,14 +398,16 @@ def test_merge_matching_clocks_lesser_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
+    site_id = get_site_id(db2)
     # no change since incoming is lesser
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, None, 1, 0)])
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, site_id, 1, 0)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
     # change since incoming is greater
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 2, None, 1, 0)])
+    site_id = get_site_id(db2)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 2, site_id, 1, 0)])
 
 
 def test_merge_larger_clock_larger_value():
@@ -414,12 +427,14 @@ def test_merge_larger_clock_larger_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 3, 2, 2, None, 1, 0)])
+    site_id = get_site_id(db1)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 3, 2, 2, site_id, 1, 0)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 3, 2, 2, None, 1, 0)])
+    site_id = get_site_id(db1)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 3, 2, 2, site_id, 1, 0)])
 
 
 def test_merge_larger_clock_smaller_value():
@@ -439,12 +454,14 @@ def test_merge_larger_clock_smaller_value():
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 0, 2, 2, None, 1, 0)])
+    site_id = get_site_id(db1)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 0, 2, 2, site_id, 1, 0)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 0, 2, 2, None, 1, 0)])
+    site_id = get_site_id(db1)
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 0, 2, 2, site_id, 1, 0)])
 
 
 def test_merge_larger_clock_same_value():
@@ -463,13 +480,15 @@ def test_merge_larger_clock_same_value():
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db1, db2, 0)
+    site_id = get_site_id(db1)
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 2, 2, None, 1, 0)])
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 2, 2, site_id, 1, 0)])
 
     (db1, db2) = make_dbs()
     sync_left_to_right(db2, db1, 0)
+    site_id = get_site_id(db1)
     changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 2, 2, None, 1, 0)])
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 2, 2, site_id, 1, 0)])
 
 # Row exists but col added thus no defaults backfilled
 


### PR DESCRIPTION
1. We compact out side ids so there isn't much advantage to making it null for local writes anymore
2. This cleans up the interface so users don't have to do weird coalescing
3. This allows us to make https://github.com/vlcn-io/cr-sqlite/pull/386 a reality by switching tie breaks to site_ids