### PR TITLE
slight optimization where we do not check `pragma_schema_version` if …

### DIFF
--- a/core/rs/core/src/c.rs
+++ b/core/rs/core/src/c.rs
@@ -56,6 +56,7 @@ pub struct crsql_ExtData {
     pub pendingDbVersion: sqlite::int64,
     pub pragmaSchemaVersion: ::core::ffi::c_int,
     pub updatedTableInfosThisTx: ::core::ffi::c_int,
+    pub readDbVersionThisTx: ::core::ffi::c_int,
     pub pragmaSchemaVersionForTableInfos: ::core::ffi::c_int,
     pub siteId: *mut ::core::ffi::c_uchar,
     pub pDbVersionStmt: *mut sqlite::stmt,
@@ -340,10 +341,20 @@ fn bindgen_test_layout_crsql_ExtData() {
         )
     );
     assert_eq!(
+        unsafe { ::core::ptr::addr_of!((*ptr).readDbVersionThisTx) as usize - ptr as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(crsql_ExtData),
+            "::",
+            stringify!(readDbVersionThisTx)
+        )
+    );
+    assert_eq!(
         unsafe {
             ::core::ptr::addr_of!((*ptr).pragmaSchemaVersionForTableInfos) as usize - ptr as usize
         },
-        48usize,
+        52usize,
         concat!(
             "Offset of field: ",
             stringify!(crsql_ExtData),

--- a/core/rs/core/src/db_version.rs
+++ b/core/rs/core/src/db_version.rs
@@ -79,6 +79,10 @@ pub fn fill_db_version_if_needed(
     ext_data: *mut crsql_ExtData,
 ) -> Result<ResultCode, String> {
     unsafe {
+        if (*ext_data).readDbVersionThisTx == 1 {
+            return Ok(ResultCode::OK);
+        }
+        (*ext_data).readDbVersionThisTx = 1;
         let rc = crsql_fetchPragmaDataVersion(db, ext_data);
         if rc == -1 {
             return Err("failed to fetch PRAGMA data_version".to_string());

--- a/core/src/crsqlite.c
+++ b/core/src/crsqlite.c
@@ -274,6 +274,7 @@ static int commitHook(void *pUserData) {
   pExtData->pendingDbVersion = -1;
   pExtData->seq = 0;
   pExtData->updatedTableInfosThisTx = 0;
+  pExtData->readDbVersionThisTx = 0;
   return SQLITE_OK;
 }
 
@@ -283,6 +284,7 @@ static void rollbackHook(void *pUserData) {
   pExtData->pendingDbVersion = -1;
   pExtData->seq = 0;
   pExtData->updatedTableInfosThisTx = 0;
+  pExtData->readDbVersionThisTx = 0;
 }
 
 int sqlite3_crsqlrustbundle_init(sqlite3 *db, char **pzErrMsg,

--- a/core/src/ext-data.c
+++ b/core/src/ext-data.c
@@ -50,6 +50,7 @@ crsql_ExtData *crsql_newExtData(sqlite3 *db, unsigned char *siteIdBuffer) {
   pExtData->tableInfos = 0;
   pExtData->rowsImpacted = 0;
   pExtData->updatedTableInfosThisTx = 0;
+  pExtData->readDbVersionThisTx = 0;
   crsql_init_table_info_vec(pExtData);
 
   int pv = crsql_fetchPragmaDataVersion(db, pExtData);

--- a/core/src/ext-data.h
+++ b/core/src/ext-data.h
@@ -22,6 +22,7 @@ struct crsql_ExtData {
   sqlite3_int64 pendingDbVersion;
   int pragmaSchemaVersion;
   int updatedTableInfosThisTx;
+  int readDbVersionThisTx;
 
   // we need another schema version number that tracks when we checked it
   // for zpTableInfos.


### PR DESCRIPTION
…already checked

in the given tx when loading db_version