### PR TITLE
switch tie-breaker to site_id

### DIFF
--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -545,6 +545,9 @@ static void noopsDoNotMoveClocks() {
   sqlite3_int64 db1vPost = getDbVersion(db1);
   sqlite3_int64 db2vPost = getDbVersion(db2);
 
+  // TODO: we still need to compare values so as not to bump the db_version
+  // forward on a no-difference
+  printf("db1 pre: %lld db2 post: %lld", db1vPre, db2vPost);
   assert(db1vPre == db2vPost);
   assert(db1vPre == db1vPost);
 

--- a/core/src/rows-impacted.test.c
+++ b/core/src/rows-impacted.test.c
@@ -314,7 +314,7 @@ static void testCreateThatDoesNotChangeAnything() {
   printf("\t\e[0;32mSuccess\e[0m\n");
 }
 
-static void testValueWin() {
+static void testValueWouldWinButSiteIdLoses() {
   printf("ValueWin\n");
   int rc = SQLITE_OK;
   char *err = 0;
@@ -326,10 +326,37 @@ static void testValueWin() {
   rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
   rc += sqlite3_exec(db,
                      "INSERT INTO crsql_changes VALUES ('foo', X'010901', 'b', "
-                     "3, 1, 1, NULL, 1, 1)",
+                     "3, 1, 1, X'00000000000000000000000000000000', 1, 1)",
                      0, 0, &err);
   sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
   sqlite3_step(pStmt);
+  // value is greater but site id lower, a loss and now rows changed.
+  assert(sqlite3_column_int(pStmt, 0) == 0);
+  sqlite3_finalize(pStmt);
+  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
+  assert(rc == SQLITE_OK);
+
+  crsql_close(db);
+  printf("\t\e[0;32mSuccess\e[0m\n");
+}
+
+static void testSiteIdWin() {
+  printf("SiteIdWin\n");
+  int rc = SQLITE_OK;
+  char *err = 0;
+  sqlite3 *db = createDb();
+  sqlite3_stmt *pStmt = 0;
+
+  rc = sqlite3_exec(db, "INSERT INTO foo VALUES (1, 2)", 0, 0, 0);
+
+  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
+  rc += sqlite3_exec(db,
+                     "INSERT INTO crsql_changes VALUES ('foo', X'010901', 'b', "
+                     "3, 1, 1, X'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF', 1, 1)",
+                     0, 0, &err);
+  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
+  sqlite3_step(pStmt);
+  // site id is larger, a win
   assert(sqlite3_column_int(pStmt, 0) == 1);
   sqlite3_finalize(pStmt);
   rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
@@ -374,7 +401,8 @@ void rowsImpactedTestSuite() {
   testUpdateThatDoesNotChangeAnything();
   testDeleteThatDoesNotChangeAnything();
   testCreateThatDoesNotChangeAnything();
-  testValueWin();
+  testValueWouldWinButSiteIdLoses();
+  testSiteIdWin();
   testClockWin();
   testDelete();
 }

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -2,4 +2,4 @@
 
 # source env/bin/activate
 # python -m pytest tests -s -k test_cl_merging
-python3 -m pytest tests -s -k test_cl_merging.py
+python3 -m pytest tests -s 

--- a/py/correctness/test.sh
+++ b/py/correctness/test.sh
@@ -2,4 +2,4 @@
 
 # source env/bin/activate
 # python -m pytest tests -s -k test_cl_merging
-python3 -m pytest tests -s 
+python3 -m pytest tests -s -k test_cl_merging.py

--- a/py/correctness/tests/test_sync.py
+++ b/py/correctness/tests/test_sync.py
@@ -155,7 +155,8 @@ def test_delete():
     close(db)
 
 
-# Row not exists case so entry created and default filled in
+# TODO: create db _then swap_ then create rows then check original invariants
+# Col? not exists case so entry created and default filled in
 def test_merging_on_defaults():
     def create_db1():
         db1 = connect(":memory:")
@@ -176,6 +177,10 @@ def test_merging_on_defaults():
     # test merging from thing with records (db2) to thing without records for default cols (db1)
     db1 = create_db1()
     db2 = create_db2()
+    if get_site_id(db1) > get_site_id(db2):
+        temp = db1
+        db1 = db2
+        db2 = temp
 
     sync_left_to_right(db2, db1, 0)
     # db1 has changes from db2
@@ -190,6 +195,10 @@ def test_merging_on_defaults():
 
     db1 = create_db1()
     db2 = create_db2()
+    if get_site_id(db1) > get_site_id(db2):
+        temp = db1
+        db1 = db2
+        db2 = temp
 
     sync_left_to_right(db1, db2, 0)
 


### PR DESCRIPTION
This is to allow us to preserve transactionality of mutations.

In conjunction with #386, this'll allow fields to be all set together or all reverted together.

E.g., a case where `x` & `y` coordinates are supposed to be updated together or not at all.