### PR TITLE
ROLLBACK TO does not alter the transaction stack

### DIFF
--- a/core/rs/core/src/automigrate.rs
+++ b/core/rs/core/src/automigrate.rs
@@ -83,7 +83,7 @@ fn automigrate_impl(
         let migrate_result = migrate_to(local_db, &mem_db);
 
         if let Err(_) = migrate_result {
-            local_db.exec_safe("ROLLBACK TO automigrate_tables")?;
+            local_db.exec_safe("ROLLBACK")?;
             let mem_db_err_msg = mem_db.errmsg()?;
             ctx.result_error(&mem_db_err_msg);
             ctx.result_error_code(mem_db.errcode());

--- a/core/rs/core/src/backfill.rs
+++ b/core/rs/core/src/backfill.rs
@@ -58,7 +58,7 @@ pub fn backfill_table(
 
     if let Err(e) = result {
         if !no_tx {
-            db.exec_safe("ROLLBACK TO backfill")?;
+            db.exec_safe("ROLLBACK")?;
         }
 
         return Err(e);
@@ -66,7 +66,7 @@ pub fn backfill_table(
 
     if let Err(e) = backfill_missing_columns(db, table, pk_cols, non_pk_cols, is_commit_alter) {
         if !no_tx {
-            db.exec_safe("ROLLBACK TO backfill")?;
+            db.exec_safe("ROLLBACK")?;
         }
 
         return Err(e);

--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -73,7 +73,7 @@ pub extern "C" fn crsql_as_table(
 
     if let Err(_) = crsql_as_table_impl(db, table) {
         ctx.result_error("failed to downgrade the crr");
-        if let Err(_) = db.exec_safe("ROLLBACK TO as_table;") {
+        if let Err(_) = db.exec_safe("ROLLBACK") {
             // fine.
         }
         return;


### PR DESCRIPTION
I didn't read the rollback docs closely enough about `ROLLBACK TO` as noticed here: https://github.com/vlcn-io/js/pull/32

What we really want is to abort all transactions if any of these operations fail. Switching to `ROLLBACK`

ty @AlexErrant 