### PR TITLE
libsql ifdefs

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -7,6 +7,7 @@ endif
 # SHARED_CFLAGS=-DLIBSQL=1
 LOADABLE_CFLAGS=-std=c99 -fPIC -shared -Wall $(SHARED_CFLAGS)
 STATIC_CFLAGS=-std=c99 -fPIC -c -Wall $(SHARED_CFLAGS)
+# libsql_feature=,libsql
 
 ifeq ($(shell uname -s),Darwin)
 CONFIG_DARWIN=y
@@ -170,19 +171,19 @@ $(sqlite3.c):
 	cd $(sqlite_src) && make sqlite3.c
 
 $(rs_lib_dbg_static_cpy): FORCE $(dbg_prefix)
-	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --features static,omit_load_extension $(rs_build_flags)
+	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --features static,omit_load_extension$(libsql_feature) $(rs_build_flags)
 	cp $(rs_lib_dbg_static) $(rs_lib_dbg_static_cpy)
 
 $(rs_lib_static_cpy): FORCE $(prefix)
-	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --release --features static,omit_load_extension $(rs_build_flags)
+	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --release --features static,omit_load_extension$(libsql_feature) $(rs_build_flags)
 	cp $(rs_lib_static) $(rs_lib_static_cpy)
 
 $(rs_lib_loadable_cpy): FORCE $(prefix)
-	cd ./rs/$(bundle) && cargo $(rs_ndk) build $(RS_TARGET) --release --features loadable_extension $(rs_build_flags)
+	cd ./rs/$(bundle) && cargo $(rs_ndk) build $(RS_TARGET) --release --features loadable_extension$(libsql_feature) $(rs_build_flags)
 	cp $(rs_lib_loadable) $(rs_lib_loadable_cpy)
 
 $(rs_lib_dbg_loadable_cpy): FORCE $(dbg_prefix)
-	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --features loadable_extension $(rs_build_flags)
+	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --features loadable_extension$(libsql_feature) $(rs_build_flags)
 	cp $(rs_lib_dbg_loadable) $(rs_lib_dbg_loadable_cpy)
 
 # Build the loadable extension.

--- a/core/Makefile
+++ b/core/Makefile
@@ -4,8 +4,9 @@ else
 CC:=$(CI_GCC)
 endif
 
-LOADABLE_CFLAGS=-std=c99 -fPIC -shared -Wall
-STATIC_CFLAGS=-std=c99 -fPIC -c -Wall
+# SHARED_CFLAGS=-DLIBSQL=1
+LOADABLE_CFLAGS=-std=c99 -fPIC -shared -Wall $(SHARED_CFLAGS)
+STATIC_CFLAGS=-std=c99 -fPIC -c -Wall $(SHARED_CFLAGS)
 
 ifeq ($(shell uname -s),Darwin)
 CONFIG_DARWIN=y

--- a/core/rs/bundle/Cargo.toml
+++ b/core/rs/bundle/Cargo.toml
@@ -25,6 +25,7 @@ panic = "abort"
 
 [features]
 test = ["crsql_core/test"]
+libsql = ["crsql_core/libsql"]
 loadable_extension = [
   "sqlite_nostd/loadable_extension",
   "crsql_fractindex_core/loadable_extension",

--- a/core/rs/bundle_static/Cargo.toml
+++ b/core/rs/bundle_static/Cargo.toml
@@ -20,6 +20,7 @@ panic = "abort"
 panic = "abort"
 
 [features]
+libsql = ["crsql_bundle/libsql"]
 test = [
   "crsql_bundle/test"
 ]

--- a/core/rs/core/Cargo.toml
+++ b/core/rs/core/Cargo.toml
@@ -26,6 +26,7 @@ panic = "abort"
 
 [features]
 test = []
+libsql = []
 loadable_extension = ["sqlite_nostd/loadable_extension"]
 static = ["sqlite_nostd/static"]
 omit_load_extension = ["sqlite_nostd/omit_load_extension"]

--- a/core/rs/core/src/backfill.rs
+++ b/core/rs/core/src/backfill.rs
@@ -1,4 +1,4 @@
-use sqlite_nostd::{sqlite3, ColumnType, Connection, Destructor, ManagedStmt, ResultCode};
+use sqlite_nostd::{sqlite3, Connection, Destructor, ManagedStmt, ResultCode};
 extern crate alloc;
 use crate::tableinfo::ColumnInfo;
 use crate::util::get_dflt_value;

--- a/core/rs/core/src/changes_vtab_write.rs
+++ b/core/rs/core/src/changes_vtab_write.rs
@@ -107,6 +107,7 @@ fn did_cid_win(
             let ret = crsql_compare_sqlite_values(insert_val, local_value);
             reset_cached_stmt(col_val_stmt.stmt)?;
             // insert site id won and values differ. We should take the update.
+            // if values are the same (ret == 0) then we return false and do not take the update
             return Ok(ret != 0);
         }
         _ => {
@@ -121,8 +122,6 @@ fn did_cid_win(
             return Err(ResultCode::ERROR);
         }
     }
-
-    return Ok(ret > 0);
 }
 
 fn set_winner_clock(

--- a/core/rs/core/src/create_cl_set_vtab.rs
+++ b/core/rs/core/src/create_cl_set_vtab.rs
@@ -256,6 +256,8 @@ static MODULE: sqlite_nostd::module = sqlite_nostd::module {
     xRelease: None,
     xRollbackTo: None,
     xShadowName: None,
+    #[cfg(feature = "libsql")]
+    xPreparedSql: None,
 };
 
 pub fn create_module(db: *mut sqlite::sqlite3) -> Result<ResultCode, ResultCode> {

--- a/core/rs/core/src/unpack_columns_vtab.rs
+++ b/core/rs/core/src/unpack_columns_vtab.rs
@@ -253,6 +253,8 @@ static MODULE: sqlite_nostd::module = sqlite_nostd::module {
     xRelease: None,
     xRollbackTo: None,
     xShadowName: None,
+    #[cfg(feature = "libsql")]
+    xPreparedSql: None,
 };
 
 /**

--- a/core/rs/integration_check/Cargo.toml
+++ b/core/rs/integration_check/Cargo.toml
@@ -21,5 +21,6 @@ libc-print = "0.1.22"
 cc = "1.0"
 
 [features]
+libsql = ["crsql_bundle/libsql"]
 static = []
 omit_load_extension = []

--- a/core/src/changes-vtab.c
+++ b/core/src/changes-vtab.c
@@ -176,5 +176,9 @@ sqlite3_module crsql_changesModule = {
     /* xSavepoint  */ 0,
     /* xRelease    */ 0,
     /* xRollbackTo */ 0,
-    /* xShadowName */ 0,
-    /* xPreparedSql */ 0};
+    /* xShadowName */ 0
+#ifdef LIBSQL
+    ,
+    /* xPreparedSql */ 0
+#endif
+};

--- a/core/src/changes-vtab.c
+++ b/core/src/changes-vtab.c
@@ -176,4 +176,5 @@ sqlite3_module crsql_changesModule = {
     /* xSavepoint  */ 0,
     /* xRelease    */ 0,
     /* xRollbackTo */ 0,
-    /* xShadowName */ 0};
+    /* xShadowName */ 0,
+    /* xPreparedSql */ 0};

--- a/libsql-sync.sh
+++ b/libsql-sync.sh
@@ -1,1 +1,7 @@
-rsync -vhra ./core/ ../libsql/libsql-sqlite3/ext/crr/ --include='**.gitignore' --exclude='**.git' --filter=':- .gitignore' --delete-after
+rsync -vhra ./core/ ../libsql/libsql-sqlite3/ext/crr/ \
+  --include='**.gitignore' \
+  --exclude='**.git' \
+  --exclude='sqlite3.h' \
+  --exclude='sqlite3ext.h' \
+  --filter=':- .gitignore' \
+  --delete-after

--- a/libsql-sync.sh
+++ b/libsql-sync.sh
@@ -1,6 +1,9 @@
 rsync -vhra ./core/ ../libsql/libsql-sqlite3/ext/crr/ \
   --include='**.gitignore' \
   --exclude='**.git' \
+  --exclude='shell.c' \
+  --exclude='sqlite3.c' \
+  --exclude='sqlite' \
   --exclude='sqlite3.h' \
   --exclude='sqlite3ext.h' \
   --filter=':- .gitignore' \


### PR DESCRIPTION
Syncing to libsql is a bit tedious. Add some `ifdefs` and `#[cfg(feature = "libsql")]` so no manual modifications are required after sync.