### PR TITLE
revert #393

### DIFF
--- a/core/src/crsqlite.test.c
+++ b/core/src/crsqlite.test.c
@@ -440,20 +440,6 @@ static sqlite3_int64 getDbVersion(sqlite3 *db) {
   return db2v;
 }
 
-static void *getSiteId(sqlite3 *db) {
-  sqlite3_stmt *pStmt = 0;
-  int rc = sqlite3_prepare_v2(db, "SELECT crsql_site_id()", -1, &pStmt, 0);
-  if (rc != SQLITE_OK) {
-    return 0;
-  }
-
-  sqlite3_step(pStmt);
-  void *site = sqlite3_column_blob(pStmt, 0);
-  sqlite3_finalize(pStmt);
-
-  return site;
-}
-
 static void testLamportCondition() {
   printf("LamportCondition\n");
   // syncing from A -> B, while no changes happen on B, moves up
@@ -525,15 +511,6 @@ static void noopsDoNotMoveClocks() {
   rc += sqlite3_open(":memory:", &db1);
   rc += sqlite3_open(":memory:", &db2);
 
-  void *db1SiteId = getSiteId(db1);
-  void *db2SiteId = getSiteId(db2);
-  int cmp = memcmp(db1SiteId, db2SiteId, 16);
-  if (cmp > 0) {
-    sqlite3 *temp = db1;
-    db1 = db2;
-    db2 = temp;
-  }
-
   // swap dbs based on site id compare to make it a noop.
 
   rc += sqlite3_exec(
@@ -570,10 +547,6 @@ static void noopsDoNotMoveClocks() {
   sqlite3_int64 db1vPost = getDbVersion(db1);
   sqlite3_int64 db2vPost = getDbVersion(db2);
 
-  // TODO: we still need to compare values so as not to bump the db_version
-  // forward on a no-difference
-  // this fails sometimes because site id winning.
-  printf("db1 pre: %lld db2 post: %lld", db1vPre, db2vPost);
   assert(db1vPre == db2vPost);
   assert(db1vPre == db1vPost);
 

--- a/core/src/rows-impacted.test.c
+++ b/core/src/rows-impacted.test.c
@@ -314,7 +314,7 @@ static void testCreateThatDoesNotChangeAnything() {
   printf("\t\e[0;32mSuccess\e[0m\n");
 }
 
-static void testValueWouldWinButSiteIdLoses() {
+static void testValueWin() {
   printf("ValueWin\n");
   int rc = SQLITE_OK;
   char *err = 0;
@@ -330,33 +330,6 @@ static void testValueWouldWinButSiteIdLoses() {
                      0, 0, &err);
   sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
   sqlite3_step(pStmt);
-  // value is greater but site id lower, a loss and now rows changed.
-  assert(sqlite3_column_int(pStmt, 0) == 0);
-  sqlite3_finalize(pStmt);
-  rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
-  assert(rc == SQLITE_OK);
-
-  crsql_close(db);
-  printf("\t\e[0;32mSuccess\e[0m\n");
-}
-
-static void testSiteIdWin() {
-  printf("SiteIdWin\n");
-  int rc = SQLITE_OK;
-  char *err = 0;
-  sqlite3 *db = createDb();
-  sqlite3_stmt *pStmt = 0;
-
-  rc = sqlite3_exec(db, "INSERT INTO foo VALUES (1, 2)", 0, 0, 0);
-
-  rc = sqlite3_exec(db, "BEGIN", 0, 0, 0);
-  rc += sqlite3_exec(db,
-                     "INSERT INTO crsql_changes VALUES ('foo', X'010901', 'b', "
-                     "3, 1, 1, X'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF', 1, 1)",
-                     0, 0, &err);
-  sqlite3_prepare_v2(db, "SELECT crsql_rows_impacted()", -1, &pStmt, 0);
-  sqlite3_step(pStmt);
-  // site id is larger, a win
   assert(sqlite3_column_int(pStmt, 0) == 1);
   sqlite3_finalize(pStmt);
   rc += sqlite3_exec(db, "COMMIT", 0, 0, 0);
@@ -401,8 +374,7 @@ void rowsImpactedTestSuite() {
   testUpdateThatDoesNotChangeAnything();
   testDeleteThatDoesNotChangeAnything();
   testCreateThatDoesNotChangeAnything();
-  testValueWouldWinButSiteIdLoses();
-  testSiteIdWin();
+  testValueWin();
   testClockWin();
   testDelete();
 }

--- a/py/correctness/tests/test_sync.py
+++ b/py/correctness/tests/test_sync.py
@@ -155,30 +155,17 @@ def test_delete():
     close(db)
 
 
-# returns two dbs. The lower site id being the first one returned.
-def create_and_swap():
-    db1 = connect(":memory:")
-    db2 = connect(":memory:")
-    if get_site_id(db1) > get_site_id(db2):
-        temp = db1
-        db1 = db2
-        db2 = temp
-
-    return (db1, db2)
-
-# TODO: create db _then swap_ then create rows then check original invariants
-# Col? not exists case so entry created and default filled in
-
-
 def test_merging_on_defaults():
-    def setup_db1_schema(db1):
+    def create_db1():
+        db1 = connect(":memory:")
         db1.execute("CREATE TABLE foo (a PRIMARY KEY NOT NULL, b DEFAULT 0);")
         db1.execute("INSERT INTO foo (a) VALUES (1);")
         db1.execute("SELECT crsql_as_crr('foo');")
         db1.commit()
         return db1
 
-    def setup_db2_schema(db2):
+    def create_db2():
+        db2 = connect(":memory:")
         db2.execute("CREATE TABLE foo (a PRIMARY KEY NOT NULL, b DEFAULT 0);")
         db2.execute("INSERT INTO foo VALUES (1, 2);")
         db2.execute("SELECT crsql_as_crr('foo');")
@@ -186,9 +173,8 @@ def test_merging_on_defaults():
         return db2
 
     # test merging from thing with records (db2) to thing without records for default cols (db1)
-    (db1, db2) = create_and_swap()
-    setup_db1_schema(db1)
-    setup_db2_schema(db2)
+    db1 = create_db1()
+    db2 = create_db2()
 
     sync_left_to_right(db2, db1, 0)
     # db1 has changes from db2
@@ -201,9 +187,8 @@ def test_merging_on_defaults():
     close(db1)
     close(db2)
 
-    (db1, db2) = create_and_swap()
-    setup_db1_schema(db1)
-    setup_db2_schema(db2)
+    db1 = create_db1()
+    db2 = create_db2()
 
     sync_left_to_right(db1, db2, 0)
 
@@ -230,19 +215,18 @@ def test_merging_on_defaults():
 # this value will be less than the default
 def test_merging_larger_backfilled_default():
     def create_dbs():
-        (db2, db1) = create_and_swap()
+        db1 = connect(":memory:")
         db1.execute("CREATE TABLE foo (a PRIMARY KEY NOT NULL, b DEFAULT 4);")
         db1.execute("INSERT INTO foo (a) VALUES (1);")
         db1.execute("SELECT crsql_as_crr('foo');")
         db1.commit()
 
+        db2 = connect(":memory:")
         db2.execute("CREATE TABLE foo (a PRIMARY KEY NOT NULL, b DEFAULT 4);")
         db2.execute("SELECT crsql_as_crr('foo');")
         db2.commit()
-
         db2.execute("INSERT INTO foo (a,b) VALUES (1,2);")
         db2.commit()
-
         return (db1, db2)
 
     (db1, db2) = create_dbs()
@@ -298,7 +282,8 @@ def test_db_version_moves_as_expected_post_alter():
 # DB2 has a row with all columns having clock records since value was set explicityl
 # The default value with no records should always be overridden in all cases
 def test_merging_on_defaults2():
-    def setup_db1_schema(db1):
+    def create_db1():
+        db1 = connect(":memory:")
         db1.execute("CREATE TABLE foo (a PRIMARY KEY NOT NULL, b DEFAULT 4);")
         db1.execute("SELECT crsql_as_crr('foo');")
         db1.commit()
@@ -314,7 +299,8 @@ def test_merging_on_defaults2():
         db1.commit()
         return db1
 
-    def setup_db2_schema(db2):
+    def create_db2():
+        db2 = connect(":memory:")
         db2.execute("CREATE TABLE foo (a PRIMARY KEY NOT NULL, b DEFAULT 4);")
         db2.execute("SELECT crsql_as_crr('foo');")
         db2.commit()
@@ -328,9 +314,9 @@ def test_merging_on_defaults2():
         db2.commit()
         return db2
 
-    (db1, db2) = create_and_swap()
-    setup_db1_schema(db1)
-    setup_db2_schema(db2)
+    # test merging from thing with records (db2) to thing without records for default cols (db1)
+    db1 = create_db1()
+    db2 = create_db2()
 
     sync_left_to_right(db2, db1, 0)
 
@@ -338,67 +324,34 @@ def test_merging_on_defaults2():
     site_id1 = get_site_id(db1)
     site_id2 = get_site_id(db2)
 
-    assert (changes == [('foo',
-                         b'\x01\t\x01',
-                         'b',
-                         2,
-                         1,
-                         2,
-                         site_id2,
-                         1,
-                         0),
-                        ('foo',
-                         b'\x01\t\x01',
-                         'c',
-                         3,
-                         1,
-                         2,
-                         site_id2,
-                         1,
-                         1)])
+    assert (changes == [('foo', b'\x01\t\x01', 'b', 4, 1, 1, site_id1, 1, 0),
+                        ('foo', b'\x01\t\x01', 'c', 3, 1, 2, site_id2, 1, 1)])
 
     close(db1)
     close(db2)
 
-    (db1, db2) = create_and_swap()
-    setup_db1_schema(db1)
-    setup_db2_schema(db2)
+    db1 = create_db1()
+    db2 = create_db2()
     site_id1 = get_site_id(db1)
     site_id2 = get_site_id(db2)
 
     sync_left_to_right(db1, db2, 0)
 
     changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
-    assert (changes == [('foo',
-                         b'\x01\t\x01',
-                         'b',
-                         2,
-                         1,
-                         1,
-                         site_id2,
-                         1,
-                         0),
-                        ('foo',
-                         b'\x01\t\x01',
-                         'c',
-                         3,
-                         1,
-                         1,
-                         site_id2,
-                         1,
-                         1)])
+    assert (changes == [  # db2 c 3 wins given columns with no value after an alter
+        # do no merging
+        ('foo', b'\x01\t\x01', 'c', 3, 1, 1, site_id2, 1, 1),
+        # Move db version since b lost on db2.
+        # b had the value 2 on db2.
+        ('foo', b'\x01\t\x01', 'b', 4, 1, 2, site_id1, 1, 0)])
 
 
 def create_basic_db():
     db = connect(":memory:")
-    setup_basic_db(db)
-    return db
-
-
-def setup_basic_db(db):
     db.execute("CREATE TABLE foo (a PRIMARY KEY NOT NULL, b);")
     db.execute("SELECT crsql_as_crr('foo');")
     db.commit()
+    return db
 
 
 def test_merge_same():
@@ -428,11 +381,10 @@ def test_merge_same():
     assert (changes == [('foo', b'\x01\t\x01', 'b', 2, 1, 1, site_id, 1, 0)])
 
 
-def test_merge_matching_clocks_lesser_siteid():
+def test_merge_matching_clocks_lesser_value():
     def make_dbs():
-        (db1, db2) = create_and_swap()
-        setup_basic_db(db1)
-        setup_basic_db(db2)
+        db1 = create_basic_db()
+        db2 = create_basic_db()
 
         db1.execute("INSERT INTO foo (a,b) VALUES (1,1);")
         db1.commit()


### PR DESCRIPTION
Why?

- This has been the behavior for over a year
- We have production deployments that we shouldn't break
- We can re-introduce site_id tie breaking as a configuration option if anyone ever needs it
- We are no longer doing `col_version = db_version` for reasons documented in https://github.com/vlcn-io/cr-sqlite/pull/405, removing the need for this change