### PR TITLE
Fix version & add a function to report the commit sha used to create the binary

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -170,19 +170,19 @@ $(shell.c):
 $(sqlite3.c):
 	cd $(sqlite_src) && make sqlite3.c
 
-$(rs_lib_dbg_static_cpy): FORCE $(dbg_prefix)
+$(rs_lib_dbg_static_cpy): FORCE write_sha $(dbg_prefix)
 	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --features static,omit_load_extension$(libsql_feature) $(rs_build_flags)
 	cp $(rs_lib_dbg_static) $(rs_lib_dbg_static_cpy)
 
-$(rs_lib_static_cpy): FORCE $(prefix)
+$(rs_lib_static_cpy): FORCE write_sha $(prefix)
 	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --release --features static,omit_load_extension$(libsql_feature) $(rs_build_flags)
 	cp $(rs_lib_static) $(rs_lib_static_cpy)
 
-$(rs_lib_loadable_cpy): FORCE $(prefix)
+$(rs_lib_loadable_cpy): FORCE write_sha $(prefix)
 	cd ./rs/$(bundle) && cargo $(rs_ndk) build $(RS_TARGET) --release --features loadable_extension$(libsql_feature) $(rs_build_flags)
 	cp $(rs_lib_loadable) $(rs_lib_loadable_cpy)
 
-$(rs_lib_dbg_loadable_cpy): FORCE $(dbg_prefix)
+$(rs_lib_dbg_loadable_cpy): FORCE write_sha $(dbg_prefix)
 	cd ./rs/$(bundle) && cargo rustc $(RS_TARGET) --features loadable_extension$(libsql_feature) $(rs_build_flags)
 	cp $(rs_lib_dbg_loadable) $(rs_lib_dbg_loadable_cpy)
 
@@ -281,3 +281,8 @@ $(TARGET_FUZZ): $(prefix) $(TARGET_SQLITE3_EXTRA_C) src/fuzzer.cc $(ext_files)
 	ubsan analyzer fuzz asan static
 
 FORCE: ;
+
+write_sha:
+	@COMMIT_SHA=`git rev-parse HEAD` && \
+	sed -i.bak "s/\"[^\"]*\"/\"$$COMMIT_SHA\"/" ./rs/core/src/sha.rs && \
+	rm -f ./rs/core/src/sha.rs.bak

--- a/core/nodejs-install-helper.js
+++ b/core/nodejs-install-helper.js
@@ -21,7 +21,7 @@ if (process.env.CRSQLITE_NOPREBUILD) {
 } else {
   // todo: check msys?
   if (["win32", "cygwin"].includes(process.platform)) {
-    os = "windows";
+    os = "win";
   }
 
   // manual ovverides for testing
@@ -36,7 +36,7 @@ if (process.env.CRSQLITE_NOPREBUILD) {
     case "linux":
       ext = "so";
       break;
-    case "windows":
+    case "win":
       ext = "dll";
       break;
   }

--- a/core/rs/core/src/consts.rs
+++ b/core/rs/core/src/consts.rs
@@ -13,6 +13,7 @@ pub const TBL_SCHEMA: &'static str = "crsql_master";
 // 00_05_01_01
 pub const CRSQLITE_VERSION: i32 = 16_01_00;
 pub const SITE_ID_LEN: i32 = 16;
+pub const SHA: &'static str = "03885434ab73d473c3ce02ac89c42cb870dba0a5";
 pub const ROWID_SLAB_SIZE: i64 = 10000000000000;
 // db version is a signed 64bit int since sqlite doesn't support saving and
 // retrieving unsigned 64bit ints. (2^64 / 2) is a big enough number to write 1

--- a/core/rs/core/src/consts.rs
+++ b/core/rs/core/src/consts.rs
@@ -12,8 +12,8 @@ pub const TBL_SCHEMA: &'static str = "crsql_master";
 // and, if we ever need it, we can track individual builds of a patch release
 // 00_05_01_01
 pub const CRSQLITE_VERSION: i32 = 16_01_00;
+pub const CRSQLITE_VERSION_STR: &'static str = "0.16.1";
 pub const SITE_ID_LEN: i32 = 16;
-pub const SHA: &'static str = "03885434ab73d473c3ce02ac89c42cb870dba0a5";
 pub const ROWID_SLAB_SIZE: i64 = 10000000000000;
 // db version is a signed 64bit int since sqlite doesn't support saving and
 // retrieving unsigned 64bit ints. (2^64 / 2) is a big enough number to write 1

--- a/core/rs/core/src/consts.rs
+++ b/core/rs/core/src/consts.rs
@@ -11,7 +11,7 @@ pub const TBL_SCHEMA: &'static str = "crsql_master";
 // 00_05_01_00
 // and, if we ever need it, we can track individual builds of a patch release
 // 00_05_01_01
-pub const CRSQLITE_VERSION: i32 = 15_00_00;
+pub const CRSQLITE_VERSION: i32 = 16_01_00;
 pub const SITE_ID_LEN: i32 = 16;
 pub const ROWID_SLAB_SIZE: i64 = 10000000000000;
 // db version is a signed 64bit int since sqlite doesn't support saving and

--- a/core/rs/core/src/sha.rs
+++ b/core/rs/core/src/sha.rs
@@ -1,0 +1,2 @@
+// The sha of the commit that this version of crsqlite was built from.
+pub const SHA: &'static str = "";


### PR DESCRIPTION
```
rlwrap ./dist/sqlite3
SQLite version 3.42.0 2023-05-16 12:36:15
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite> select crsql_sha();
53c08576a4b3c27a2423ff2b4143cdd38ff402f5
sqlite>
```