### PR TITLE
[core/rs/{bundle/src/lib.rs,fractindex-core/src/lib.rs}] Resolve two `unused import` warnings

### DIFF
--- a/core/rs/bundle/src/lib.rs
+++ b/core/rs/bundle/src/lib.rs
@@ -5,7 +5,6 @@
 extern crate alloc;
 
 use core::alloc::GlobalAlloc;
-use core::alloc::Layout;
 use core::ffi::c_char;
 use core::panic::PanicInfo;
 use crsql_core;

--- a/core/rs/fractindex-core/src/lib.rs
+++ b/core/rs/fractindex-core/src/lib.rs
@@ -8,7 +8,6 @@ mod fractindex_view;
 mod util;
 
 use core::ffi::{c_char, c_int};
-use core::slice;
 pub use fractindex::*;
 use fractindex_view::fix_conflict_return_old_key;
 use sqlite::args;


### PR DESCRIPTION
Other warnings I found are:
```
warning: unused variable: `argc`
   --> cr-sqlite/core/rs/core/src/lib.rs:776:5
    |
776 |     argc: i32,
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_argc`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `argv`
   --> cr-sqlite/core/rs/core/src/lib.rs:777:5
    |
777 |     argv: *mut *mut sqlite::value,
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_argv`

warning: unused variable: `argc`
   --> cr-sqlite/core/rs/core/src/lib.rs:784:5
    |
784 |     argc: i32,
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_argc`

warning: unused variable: `argv`
   --> cr-sqlite/core/rs/core/src/lib.rs:785:5
    |
785 |     argv: *mut *mut sqlite::value,
    |     ^^^^ help: if this is intentional, prefix it with an underscore: `_argv`

warning: function `x_crsql_version` is never used
   --> cr-sqlite/core/rs/core/src/lib.rs:782:22
    |
782 | unsafe extern "C" fn x_crsql_version(
    |                      ^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: constant `CRSQLITE_VERSION_STR` is never used
  --> cr-sqlite/core/rs/core/src/consts.rs:15:11
   |
15 | pub const CRSQLITE_VERSION_STR: &'static str = "0.16.3";
   |           ^^^^^^^^^^^^^^^^^^^^

warning: `crsql_fractindex_core` (lib) generated 1 warning (run `cargo fix --lib -p crsql_fractindex_core` to apply 1 suggestion)
   Compiling crsql_bundle v0.1.0 (cr-sqlite/core/rs/bundle)
warning: the feature `lang_items` is internal to the compiler or standard library
 --> cr-sqlite/core/rs/bundle/src/lib.rs:3:12
  |
3 | #![feature(lang_items)]
  |            ^^^^^^^^^^
  |
  = note: using it is strongly discouraged
  = note: `#[warn(internal_features)]` on by default
```

It might be worthwhile to add the SQLite version to the `.data` section so we can easily find what version of SQLite the shared library was built against (without linking it first). I suppose putting it in the header would be worthwhile also; preferably as a `#define`.