### PR TITLE
Fix missing null terminator in schema name

### DIFF
--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -557,7 +557,7 @@ unsafe extern "C" fn x_crsql_as_crr(
     let (schema_name, table_name) = if argc == 2 {
         (args[0].text(), args[1].text())
     } else {
-        ("main", args[0].text())
+        ("main\0", args[0].text())
     };
 
     let db = ctx.db_handle();


### PR DESCRIPTION
So we were having some issues in release builds, apparently there is an undefined behavior conversion from "main" (rust string, NOT NULL TERMINATED) to &str using `CStr::from_ptr` (which expects a null terminated string)

This seems to be a decent fix, although you might want to go over similar code, there might be cases I missed.
Also the error codes are slightly vague, since all these conversions just return "out of memory" even though it's not what's going on.
Thanks.