### PR TITLE
fix plist

### DIFF
--- a/core/all-ios-loadable.sh
+++ b/core/all-ios-loadable.sh
@@ -24,6 +24,12 @@ function createXcframework() {
   <string>FMWK</string>
   <key>CFBundleSignature</key>
   <string>????</string>
+  <key>CFBundleVersion</key>
+  <string>1.0.0</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+	<key>MinimumOSVersion</key>
+  <string>8.0</string>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
Currently there’s an issue submitting an app to the Apple App Store due to a missing version definitions in the cr-sqlite plist files.
For reference, expo-sqlite have experienced the same (see commit https://github.com/expo/expo/commit/de2a96986b29ebc8c71e291a12121e00290e9986)
This PR adds the missing version definitions and allows the app to be submitted to App Store without Apple rejecting the binary.