### PR TITLE
fix deprecated import assertion

### DIFF
--- a/core/nodejs-install-helper.js
+++ b/core/nodejs-install-helper.js
@@ -6,7 +6,7 @@
 import { join } from "path";
 import fs from "fs";
 import https from "https";
-import pkg from "./package.json" assert { type: "json" };
+import pkg from "./package.json" with { type: "json" };
 import { exec } from "child_process";
 let { version } = pkg;
 


### PR DESCRIPTION
`import something from "somewhere" assert { type: "json" };` has been deprecated in favour of `import something from "somewhere" with { type: "json" };`. Therefore on the latest node versions (tested on `22.2.0` and `22.3.0`) the library just doesn't install:

```
import pkg from "./package.json" assert { type: "json" };
                                 ^^^^^^

SyntaxError: Unexpected identifier 'assert'
    at compileSourceTextModule (node:internal/modules/esm/utils:337:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:164:18)
    at callTranslator (node:internal/modules/esm/loader:429:14)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:435:30)
    at async ModuleJob._link (node:internal/modules/esm/module_job:106:19)

Node.js v22.3.0
```

This is a simple fix that changes `assert` to `with` in `nodejs-install-helper.js`.

### NodeJS Docs

https://nodejs.org/docs/v20.15.0/api/esm.html#import-attributes

> This feature was previously named "Import assertions", and using the assert keyword instead of with. Any uses in code of the prior assert keyword should be updated to use with instead.