### PR TITLE
Align Android loadable to 16 KB page size

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -253,7 +253,7 @@ jobs:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
         run: |
           cd core
-          export ANDROID_TARGET=aarch64-linux-android; make loadable
+          export ANDROID_TARGET=aarch64-linux-android; make SHARED_CFLAGS="-Wl,-z,max-page-size=16384" loadable
           cd dist; zip crsqlite.zip ${{ matrix.library_name }}
 
       - name: Upload binaries to release


### PR DESCRIPTION
Android 15 requires shared libraries to have 16 KB aligned load segments, but the published `crsqlite-aarch64-linux-android.so` is aligned to 4 KB and fails to load on 16 KB page size devices. Passing `-Wl,-z,max-page-size=16384` to the loadable build fixes it without changing the NDK version. 