### PR TITLE
fix: ios simulator build

### DIFF
--- a/core/all-ios-loadable.sh
+++ b/core/all-ios-loadable.sh
@@ -3,6 +3,12 @@
 # a hacky script to make all the various ios targets.
 # once we have something consistently working we'll streamline all of this.
 
+set -euo pipefail
+
+# bindgen hands the rust triple to clang, which rejects `sim` as a version.
+# clang spells the same target `arm64-apple-ios-simulator`.
+export BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios_sim="--target=arm64-apple-ios-simulator"
+
 BUILD_DIR=./build
 DIST_PACKAGE_DIR=./dist
 


### PR DESCRIPTION
`all-ios-loadable.sh` publishes an empty archive. bindgen passes the rust triple to clang, which rejects it: `error: version 'sim' in target triple 'arm64-apple-ios-sim' is invalid`. clang spells it `arm64-apple-ios-simulator`, which the Makefile already works around for the C compile but nothing applies to the Rust build, so `BINDGEN_EXTRA_CLANG_ARGS_aarch64_apple_ios_sim` sets it.

`xcframework` needs both slices, so losing the simulator loses the whole artifact, and without `set -e` the script tars a missing directory and exits 0. The released tarball is 29 bytes on current runners; with this change it is 1.16 MB containing `ios-arm64` and `ios-arm64_x86_64-simulator`.
